### PR TITLE
fix: Include abstained votes in quorum count

### DIFF
--- a/src/config/proposals.json
+++ b/src/config/proposals.json
@@ -2114,6 +2114,7 @@
     "title": "Allocate $1M of Mento’s Current Reserve Holdings to Glo Dollar to fund Celo Public Goods at no cost",
     "author": "Garm Lucassen (Glo Dollar)",
     "stage": 1,
+    "id": 183,
     "url": "https://forum.celo.org/t/draft-allocate-1m-of-mento-s-current-reserve-holdings-to-glo-dollar-to-fund-celo-public-goods-at-no-cost/7927",
     "timestamp": 1721779200000
   },
@@ -2126,5 +2127,15 @@
     "stage": 0,
     "url": "https://forum.celo.org/t/final-proposal-to-enable-account-abstraction-erc-4337-on-celo-s-upcoming-l2-leveraging-biconomy-s-aa-infrastructure/8266/9",
     "timestamp": 1722470400000
+  },
+  {
+    "cgp": 144,
+    "cgpUrl": "https://github.com/celo-org/governance/blob/main/CGPs/cgp-0144.md",
+    "cgpUrlRaw": "https://raw.githubusercontent.com/celo-org/governance/main/CGPs/cgp-0144.md",
+    "title": "Artemis Proposal to Build Public Goods Data Dashboards for Celo Ecosystem and Community",
+    "author": "Anthony Yim (@andromedae88)",
+    "stage": 0,
+    "url": "https://forum.celo.org/t/draft-artemis-proposal-to-build-public-goods-data-dashboards-for-celo-ecosystem-and-community/8384",
+    "timestamp": 1722902400000
   }
 ]

--- a/src/features/governance/components/ProposalVoteChart.tsx
+++ b/src/features/governance/components/ProposalVoteChart.tsx
@@ -66,22 +66,24 @@ export function ProposalQuorumChart({ propData }: { propData: MergedProposalData
   const quorumRequired = useProposalQuorum(propData);
 
   const yesVotes = votes?.[VoteType.Yes] || 0n;
+  const abstainVotes = votes?.[VoteType.Abstain] || 0n;
+  const quorumMeetingVotes = yesVotes + abstainVotes;
 
   const quorumBarChartData = useMemo(
     () => [
       {
         label: 'Yes votes',
-        value: fromWei(yesVotes),
-        percentage: percent(yesVotes, quorumRequired || 1n),
+        value: fromWei(quorumMeetingVotes),
+        percentage: percent(quorumMeetingVotes, quorumRequired || 1n),
         color: Color.Wood,
       },
     ],
-    [yesVotes, quorumRequired],
+    [quorumMeetingVotes, quorumRequired],
   );
 
   return (
     <div className="space-y-2 border-t border-taupe-300 pt-2">
-      <Amount valueWei={yesVotes} className="text-2xl" decimals={0} />
+      <Amount valueWei={quorumMeetingVotes} className="text-2xl" decimals={0} />
       <StackedBarChart data={quorumBarChartData} showBorder={false} className="bg-taupe-300" />
       <div className="flex items-center text-sm text-taupe-600">
         {`Quorum required: ${formatNumberString(quorumRequired, 0, true)} CELO`}

--- a/src/scripts/collectProposalMetadata.ts
+++ b/src/scripts/collectProposalMetadata.ts
@@ -13,7 +13,7 @@ BigInt.prototype.toJSON = function () {
 };
 
 const PROPOSALS_OUT_PATH = path.resolve(__dirname, '../config/proposals.json');
-const MIN_PROPOSAL_ID_VOTES_FETCH = 160;
+const MIN_PROPOSAL_ID_VOTES_FETCH = 180;
 
 async function main() {
   let cachedProposals: ProposalMetadata[] = [];


### PR DESCRIPTION
Fix requested by @marekolszewski 

As demonstated by proposal [183](https://mondo.celo.org/governance/cgp-142), abstained votes are actually counted towards quorum requirements.

This fixes the quorum stacked bar chart

And a drive-by update of the proposal cache