### PR TITLE
improve pr experience regarding prettifying files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
           yarn run prettier
           CHANGES=$(git status -s)
           if [[ ! -z $CHANGES ]]; then
-            echo "Changes found: $CHANGES"
+            echo "Changes found"
+            git diff
             exit 1
           fi
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged
+yarn prettier


### PR DESCRIPTION
Most people who open a pr to add a delegate do so by using github ui. They are probably not developers so running commands like yarn prettier is a bit much. We should try to do this for them. but also we are lazy and there are many so we should try to automate prettifying files so as to not hold up prs for it 

A) show the diff when prettier has changes in ci
B) run prettier on commit (hopefully this means A never happens but insurance is nice since there is the git commit --no-checks bypass)


