### PR TITLE
Fix incorrect LuukDAO logo URL in delegates.json

### DIFF
--- a/src/config/delegates.json
+++ b/src/config/delegates.json
@@ -13,7 +13,7 @@
   "0x31cd90C2788f3e390d2Bb72871f5aD3F1a4B22a1": {
     "name": "LuukDAO",
     "address": "0x31cd90C2788f3e390d2Bb72871f5aD3F1a4B22a1",
-    "logoUri": "/logos/delegatees/Luukdao.jpeg",
+    "logoUri": "/logos/delegatees/LuukDAO.jpg",
     "date": "2024-08-12",
     "links": {
       "website": "https://forum.celo.org/t/steward-thread-luukdao/7460",


### PR DESCRIPTION
As shown in the figure, the image cannot be loaded due to incorrect URL pointing to the file

![image](https://github.com/user-attachments/assets/90efd1c8-f663-4657-a607-83aa8c2f4389)
