### PR TITLE
Automatically comment prettier diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
             git diff
             exit 1
           fi
+      - name: Comment with diff as suggested change               
+        uses: parkerbxyz/suggest-changes@v1.0.5   
+        with: 
+          comment: "The following changes were found while running prettier. Commit them for a ✅" 
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,20 +63,21 @@ jobs:
             .yarn/cache
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
-      - name: prettier
+      - name: prettier run
         run: |
           yarn run prettier
+      - name: Comment with diff as suggested change               
+        uses: parkerbxyz/suggest-changes@v1.0.5   
+        with: 
+          comment: "The following changes were found while running prettier. Commit them for a ✅" 
+      - name: prettier results
+        run: 
           CHANGES=$(git status -s)
           if [[ ! -z $CHANGES ]]; then
             echo "Changes found"
             git diff
             exit 1
           fi
-      - name: Comment with diff as suggested change               
-        uses: parkerbxyz/suggest-changes@v1.0.5   
-        with: 
-          comment: "The following changes were found while running prettier. Commit them for a ✅" 
-
   lint:
     runs-on: ubuntu-latest
     needs: [install]

--- a/src/config/delegates.json
+++ b/src/config/delegates.json
@@ -8,7 +8,7 @@
       "website": "https://forum.celo.org/t/steward-thread-luukdao/7460",
       "twitter": "https://twitter.com/LuukDAO"
     },
-    "interests": ["ReFi", "Stablecoins", "DeFi", "Public Goods", "Superchain"],
+    "interests": [ "ReFi", "Stablecoins", "DeFi", "Public Goods", "Superchain"],
     "description": "I’m committed entirely to enabling Regeneration at scale and wholeheartedly believe Celo’s vision to build a digital economy that creates conditions for all is a foundation required to realize my mission. As a Celo Builder, I want to support Celo’s development and good governance, and believe my experience as a Web3 delegate and founder can help progress Celo. I have 5+ years of experience participating in leading DAOs, including PrimeDAO, BalancerDAO, SafeDAO, and Optimism."
   },
   "0xC20F4412fa84b33e0f3657113736F229a811A285": {


### PR DESCRIPTION
When prettier runs and has a diff that will cause the pr to not be mergable.

Since we cant make commits on a fork from a gh action and commits made on gh ui dont run precommit hooks this action will leave a commit on the pr with the changes to be made. saving both maintainers and contributors from needing to pull and run prettier locally, 