### PR TITLE
fix: add CORS rules for safe.global support

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,13 +16,20 @@ const CONNECT_SRC_HOSTS = [
   'https://raw.githubusercontent.com',
   'https://celo-mainnet.infura.io',
   'https://qstash.upstash.io',
+  'https://app.safe.global',
+  'https://*.rainbow.me',
 ];
-const FRAME_SRC_HOSTS = ['https://*.walletconnect.com', 'https://*.walletconnect.org'];
-const IMG_SRC_HOSTS = ['https://*.walletconnect.com'];
+const FRAME_SRC_HOSTS = [
+  'https://*.walletconnect.com',
+  'https://*.walletconnect.org',
+  'https://app.safe.global',
+];
+const IMG_SRC_HOSTS = ['https://*.walletconnect.com', 'https://app.safe.global'];
+const SCRIPTS_SRC_HOSTS = ['https://*.safe.global'];
 
 const cspHeader = `
   default-src 'self';
-  script-src 'self'${isDev ? " 'unsafe-eval'" : ''};
+  script-src 'self' ${isDev ? "'unsafe-eval'" : SCRIPTS_SRC_HOSTS.join(' ')};
   script-src-elem 'self' 'unsafe-inline';
   style-src 'self' 'unsafe-inline';
   connect-src 'self' ${CONNECT_SRC_HOSTS.join(' ')};
@@ -32,7 +39,7 @@ const cspHeader = `
   base-uri 'self';
   form-action 'self';
   frame-src 'self' ${FRAME_SRC_HOSTS.join(' ')};
-  frame-ancestors 'none';
+  frame-ancestors 'self' ${FRAME_SRC_HOSTS.join(' ')};
   ${!isDev ? 'block-all-mixed-content;' : ''}
   ${!isDev ? 'upgrade-insecure-requests;' : ''}
 `
@@ -46,7 +53,7 @@ const securityHeaders = [
   },
   {
     key: 'X-Frame-Options',
-    value: 'DENY',
+    value: `ALLOW-FROM ${FRAME_SRC_HOSTS.join(' ')}`,
   },
   {
     key: 'X-Content-Type-Options',
@@ -77,6 +84,18 @@ module.exports = {
       {
         source: '/(.*)',
         headers: securityHeaders,
+      },
+      {
+        // This allow the manifest to be fetched and used by safe.global
+        source: '/manifest.json',
+        headers: [
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          { key: 'Access-Control-Allow-Methods', value: 'GET' },
+          {
+            key: 'Access-Control-Allow-Headers',
+            value: 'X-Requested-With, content-type, Authorization',
+          },
+        ],
       },
     ];
   },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,1 @@
+site.webmanifest

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,7 @@
 {
     "name": "Celo Mondo",
     "short_name": "Celo Mondo",
+    "description": "Celo Mondo is a DApp for participating in staking and governance on Celo.\n\nEarn rewards by locking & staking your CELO tokens. Help decide Celo's destiny by casting your vote in on-chain governance proposals.",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
Change CORS rules in order to be embedded in `app.safe.global` and make sure `manifest.json` is accessible too as that's how they add apps.

![Screenshot 2024-10-08 at 10 57 52](https://github.com/user-attachments/assets/07675de9-bcb4-4d9a-89b2-6aa578743bf2)


Follow-up task: request adding the app to officials apps.

https://docs.google.com/forms/d/e/1FAIpQLSeN2m94-jvGjvUF9MpZSkwxGPPjNz7QKZj9h9kMVXvnNdp2Mg/viewform

![Screenshot 2024-10-08 at 10 59 19](https://github.com/user-attachments/assets/f8dad77b-681b-40b2-8a25-7c817976f6ee)



[Closes #57]
