### PR TITLE
Add Prosperity Accounts X-Frame support

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,14 +18,16 @@ const CONNECT_SRC_HOSTS = [
   'https://celo-mainnet.infura.io',
   'https://qstash.upstash.io',
   'https://app.safe.global',
+  'https://account.celopg.eco',
   'https://*.rainbow.me',
 ];
 const FRAME_SRC_HOSTS = [
   'https://*.walletconnect.com',
   'https://*.walletconnect.org',
   'https://app.safe.global',
+  'https://account.celopg.eco',
 ];
-const IMG_SRC_HOSTS = ['https://*.walletconnect.com', 'https://app.safe.global'];
+const IMG_SRC_HOSTS = ['https://*.walletconnect.com', 'https://app.safe.global', 'https://account.celopg.eco',];
 const SCRIPTS_SRC_HOSTS = ['https://*.safe.global'];
 
 const cspHeader = `


### PR DESCRIPTION
# Add X-Frame header for account.celopg.eco
As Prosperity accounts are part of the [Celo Citizen round](https://forum.celo.org/t/celo-citizen-retro-round-details/9637?utm_medium=email&_hsenc=p2ANqtz-96lBFEPbCAs7Wl-8vNAkX2DiB34ijaZNivbPoLYBOqx7_7BbZRSglTFtl9MXKtb43Fc62-2qZ8QmxVFO414b-BYnaqkQ&_hsmi=339252450&utm_content=339252450&utm_source=hs_email) for phase 2 (Onchain Usage (Citizenship) Rewards), it is important to add this header to enable the embedded rendering of Celo Mondo, similar to how Safe Wallet operates.

![image](https://github.com/user-attachments/assets/7d2bd864-4e53-41cc-85bc-ad3248410b08)
