### PR TITLE
Fix shown amounts for stakers of a vgroup

### DIFF
--- a/src/features/validators/useValidatorStakers.ts
+++ b/src/features/validators/useValidatorStakers.ts
@@ -36,12 +36,15 @@ export function useValidatorStakers(group?: Address) {
       gcTime: 2 * 60 * 60 * 1000,
       staleTime: 60 * 60 * 1000, // 1 hour
     },
-    contracts: accounts.map((account) => ({
-      address: Addresses.Election,
-      abi: electionABI,
-      functionName: 'getActiveVotesForGroupByAccount',
-      args: [group!, account],
-    })),
+    contracts: accounts.map(
+      (account) =>
+        ({
+          address: Addresses.Election,
+          abi: electionABI,
+          functionName: 'getActiveVotesForGroupByAccount',
+          args: [group!, account],
+        }) as const,
+    ),
   });
 
   let aggregateData: Array<[Address, number]> = [];
@@ -57,7 +60,6 @@ export function useValidatorStakers(group?: Address) {
   useToastError(accurateStakes.error, 'Error fetching staked amounts');
 
   return {
-    // @ts-ignore accurate stakes type initialization is deep
     isLoading: isLoading || accurateStakes.isLoading,
     isError: isError || accurateStakes.isError,
     stakers: aggregateData,


### PR DESCRIPTION
## description

log Queries on celoscan (our data provider) are limited to 1000 per page. But only page 1 was being fetched. it now continues to fetch if exactly 1000 queries are found. This gets us the correct current voters. But the amounts are still off so  after reducing to current voters use multicall to fetch the accurate amounts. Bonisimo!

The staked amounts now match the amount shown in celocli

## other

* display with ShortAddress so the address can be copied 

## results

### before
<img width="842" alt="Screenshot 2025-01-10 at 4 10 15 PM" src="https://github.com/user-attachments/assets/b9cfaf7c-4736-4402-b0a7-b42362aac56b" />

### after
<img width="912" alt="Screenshot 2025-01-10 at 4 10 28 PM" src="https://github.com/user-attachments/assets/839d7f62-aa29-4949-b284-5b8909736f72" />


## issue
#131 