### PR TITLE
improves handling off odd situation states for governance proposals.

### DIFF
--- a/src/app/governance/[id]/markdown-api/route.ts
+++ b/src/app/governance/[id]/markdown-api/route.ts
@@ -1,7 +1,8 @@
-export const revalidate = 60 * 2;
+export const revalidate = 60 * 3;
 
 const URL_BASE = 'https://raw.githubusercontent.com/celo-org/governance/main/CGPs/cgp-';
 
+// TODO consider doing more parsing of yaml / markdown here instead of in browser
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const url = URL_BASE + zeroPad(id) + '.md';

--- a/src/config/delegatees/0xba3982536F79090D4d68cD14e1B7d15fF1014030.json
+++ b/src/config/delegatees/0xba3982536F79090D4d68cD14e1B7d15fF1014030.json
@@ -4,15 +4,13 @@
   "logoUri": "/logos/delegatees/0xba3982536F79090D4d68cD14e1B7d15fF1014030.jpeg",
   "date": "2025-01-29",
   "links": {
-    "website": "https://celo.org",
     "twitter": "https://x.com/ndukaanthonya"
   },
   "interests": [
     "Community",
     "NFTs",
     "DAO",
-    "Stablecoins",
-    ""
+    "Stablecoins"
   ],
   "description": "Community Developer"
 }

--- a/src/config/delegates.json
+++ b/src/config/delegates.json
@@ -8,13 +8,7 @@
       "website": "https://forum.celo.org/u/pcbo/summary",
       "twitter": "https://x.com/pcbo"
     },
-    "interests": [
-      "SocialFi",
-      "Reputation",
-      "Identity",
-      "Public Goods",
-      "Superchain"
-    ],
+    "interests": ["SocialFi", "Reputation", "Identity", "Public Goods", "Superchain"],
     "description": "Considering my Celo Public Goods 2024 H2 Steward role is coming to an end, I want to continue to give-back to the Celo community now as a outspoken Delegate. I believe that I bring an unique POV as a Delegate based on my experience as a multi-startup founder, unique HR Tech builder background, bear-market survivor builder making the rounds over at Talent Protocol to build a new better reputation engine for professional work."
   },
   "0x3e737AD3234a127066043D5Df2ABF7adDEC79c2b": {
@@ -25,12 +19,7 @@
     "links": {
       "website": "https://forum.celo.org/u/0xgoldo/summary"
     },
-    "interests": [
-      "Community",
-      "Defi",
-      "Decentralization",
-      "Transparency"
-    ],
+    "interests": ["Community", "Defi", "Decentralization", "Transparency"],
     "description": "Hi Celorians! I am a member of the Celo Guardians team (formerly known as 'CGP Editors'), the decentralized working group that is helping to mantain and organize the Celo Governance. I am also part of the Moderators team, a role that require myself to be involved and up to date around everything happening on Celo and his ecosystem. As a Celo Delegate, my motivation is rooted in the desire to support a decentralized, inclusive, and environmentally conscious financial ecosystem. I believe in Celo’s mission to bring prosperity to all by leveraging blockchain technology, particularly in providing financial tools to underserved communities globally."
   },
   "0x8b37a5Af68D315cf5A64097D96621F64b5502a22": {
@@ -42,11 +31,7 @@
       "website": "https://www.areta.io/",
       "twitter": "https://x.com/areta_io"
     },
-    "interests": [
-      "Governance Design",
-      "Ecosystem Growth",
-      "Decentralization"
-    ],
+    "interests": ["Governance Design", "Ecosystem Growth", "Decentralization"],
     "description": "Areta Governance specializes in supporting DAOs and foundations to establish and grow decentralized governance structures. We develop tailored solutions in governance inception and optimization, ecosystem growth, and service provider selection. Our connected investment bank with deep strategic expertise, enables us to serve our partners holistically, rather than working in isolated governance silos. ​We have had the privilege to work alongside industry leaders such as Uniswap, Arbitrum, Safe, Aave, and dYdX."
   },
   "0x3c3Eb5C41720D555F81eD554e901edD0a6aF228C": {
@@ -58,12 +43,7 @@
       "website": "https://www.stake.capital/",
       "twitter": "https://x.com/StakeCapital"
     },
-    "interests": [
-      "Proof-of-Stake",
-      "High Availability",
-      "Infrastructure",
-      "Web3 Investment"
-    ],
+    "interests": ["Proof-of-Stake", "High Availability", "Infrastructure", "Web3 Investment"],
     "description": "Stake Capital is a trusted and experienced blockchain investment firm, actively contributing to the blockchain ecosystem since 2016. With expertise in venture capital, incubation, acceleration, and validation, we ensure robust participation in governance through our mainnet validation for top projects and our involvement in testnets for emerging infrastructures. Our commitment to excellence and transparency makes us a reliable partner to delegate your voting power, helping to secure and innovate within the Celo network."
   },
   "0x2D7d6Ec6198ADFD5850D00BD601958F6E316b05E": {
@@ -88,12 +68,7 @@
     "logoUri": "/logos/delegatees/oliseh.jpg",
     "date": "2024-05-09",
     "links": {},
-    "interests": [
-      "Discovery",
-      "Engaged",
-      "Calm",
-      "Love"
-    ],
+    "interests": ["Discovery", "Engaged", "Calm", "Love"],
     "description": "Oliseh is unbaised , belives in Celo and more so a passive builder. Got into the Celo ecosystem through Celo Africa Dao but everyday building new products for the ecosystem"
   },
   "0x657D07095b082BB71ebD93F549f407A97f49094F": {
@@ -104,12 +79,7 @@
     "links": {
       "twitter": "https://twitter.com/0xMims"
     },
-    "interests": [
-      "DAO Design",
-      "Fitness",
-      "Language Learning",
-      "Cooking"
-    ],
+    "interests": ["DAO Design", "Fitness", "Language Learning", "Cooking"],
     "description": "I’ve been committed to the crypto ecosystem for about three years now. I had my start with FranklinDAO/Penn Blockchain on its research committee. Since graduating a few months ago, I’ve been honored to be welcomed into the Blockworks team on their protocol services wing. I am currently representing Blockworks across multiple DAOs and we perform applied research to help push DAOs into new directions. To be explicit though, my interest in Celo is personal, not occupational, and I seek to help expand Celo’s regeneration initiative and help enforce its public-goods identity. While I have no prior forum history, I certainly have the background and history that would describe me as a long-term participant."
   },
   "0x720c293071a9e084c3A8c82F42c98065Be546FcC": {
@@ -120,12 +90,7 @@
     "links": {
       "twitter": "https://twitter.com/xlzy905"
     },
-    "interests": [
-      "Technology",
-      "Development",
-      "Community",
-      "Innovation"
-    ],
+    "interests": ["Technology", "Development", "Community", "Innovation"],
     "description": "Hello, Celo Community! I am an experienced web3 developer deeply committed to the Celo ecosystem. With a strong background in blockchain technology and a passion for innovative solutions, I've been actively contributing to various web3 projects. I firmly believe in Celo's vision of creating a more accessible and inclusive financial system. My goal is to contribute to Celo's growth while ensuring that our decisions align with the best interests of both the technology and the community it serves."
   },
   "0x31cd90C2788f3e390d2Bb72871f5aD3F1a4B22a1": {
@@ -137,13 +102,7 @@
       "website": "https://forum.celo.org/t/steward-thread-luukdao/7460",
       "twitter": "https://twitter.com/LuukDAO"
     },
-    "interests": [
-      "ReFi",
-      "Stablecoins",
-      "DeFi",
-      "Public Goods",
-      "Superchain"
-    ],
+    "interests": ["ReFi", "Stablecoins", "DeFi", "Public Goods", "Superchain"],
     "description": "I’m committed entirely to enabling Regeneration at scale and wholeheartedly believe Celo’s vision to build a digital economy that creates conditions for all is a foundation required to realize my mission. As a Celo Builder, I want to support Celo’s development and good governance, and believe my experience as a Web3 delegate and founder can help progress Celo. I have 5+ years of experience participating in leading DAOs, including PrimeDAO, BalancerDAO, SafeDAO, and Optimism."
   },
   "0xC20F4412fa84b33e0f3657113736F229a811A285": {
@@ -154,12 +113,7 @@
     "links": {
       "twitter": "https://twitter.com/_iamoracle"
     },
-    "interests": [
-      "Community",
-      "Transparency",
-      "Accountability",
-      "Good Vibes"
-    ],
+    "interests": ["Community", "Transparency", "Accountability", "Good Vibes"],
     "description": "Hello, Community! I am a developer, a 6x Hackathon winner (of which 4 are Celo-organized) and a founder within the Celo Ecosystem. I have previously served as a DevRel Community Moderator, and I have been supporting developers across the ecosystem. I am willing to use my experience to help review technical proposals and vote accordingly in the governance process."
   },
   "0xFEF5A1A2b3754A2F53161EaaAcb3EB889F004d4a": {
@@ -171,12 +125,7 @@
       "website": "https://linktr.ee/0xj4an_work",
       "twitter": "https://twitter.com/0xj4an"
     },
-    "interests": [
-      "Community",
-      "Transparency",
-      "Accountability",
-      "Good Vibes"
-    ],
+    "interests": ["Community", "Transparency", "Accountability", "Good Vibes"],
     "description": "Hey, I am a member of the Celo Guardians (formerly known as 'CGP Editors'). I help maintain the history of governance proposals and am an active contributor to the Celo community."
   },
   "0xd42Bb7FE32cDf68045f49553c6f851fD2c58B6a9": {
@@ -188,13 +137,7 @@
       "website": "https://linktr.ee/reficolombia",
       "twitter": "https://twitter.com/reficolombia"
     },
-    "interests": [
-      "ReFi",
-      "Community",
-      "Transparency",
-      "Accountability",
-      "Good Vibes"
-    ],
+    "interests": ["ReFi", "Community", "Transparency", "Accountability", "Good Vibes"],
     "description": "Our mission is clear, we commit to allocating all of our validator gains towards empowering the ReFi movement in Colombia and supporting individuals in need. Our dedication goes beyond securing the network; we are determined to leverage all of our gains to support the ReFi movement in Colombia.🇨🇴"
   },
   "0xFaa0b40645Ee5E8D9AE38393e8cDF8e5baA71d13": {
@@ -206,10 +149,7 @@
       "website": "https://staking.fund",
       "twitter": "https://twitter.com/stakingfund"
     },
-    "interests": [
-      "Proof-of-Stake",
-      "Infrastructure"
-    ],
+    "interests": ["Proof-of-Stake", "Infrastructure"],
     "description": "Staking Fund operates block producing validation nodes on Proof-of-Stake protocols.  We've been actively engaging in the validating role for numerous novel Proof-of-Stake protocols since 2018 and proving our commitment to secure decentralized blockchain networks with high availability and zero slashing."
   },
   "0xD72Ed2e3db984bAC3bB351FE652200dE527eFfcf": {
@@ -221,11 +161,7 @@
       "website": "https://chainvibes.com/decloud.html",
       "twitter": "https://twitter.com/chain_vibes"
     },
-    "interests": [
-      "Transparency",
-      "Accountability",
-      "Good Vibes"
-    ],
+    "interests": ["Transparency", "Accountability", "Good Vibes"],
     "description": "Chain vibes is a validator group. We are transparent about our on-chain governance decision making as well as our commission change rate schedule. Our whole live is about IT engineering, now we take this opportunity to keep the vibe in the chain"
   },
   "0x0339Df3FE4f5ccC864EAE8491E5c8AEc4611A631": {
@@ -237,10 +173,7 @@
       "website": "https://tessellated.io",
       "twitter": "https://twitter.com/tessellated_io"
     },
-    "interests": [
-      "Proof-of-Stake",
-      "Infrastructure"
-    ],
+    "interests": ["Proof-of-Stake", "Infrastructure"],
     "description": "Tessellated is an independent and technically capable validator. Tessellated has validated and contributed to networks since 2018."
   },
   "0xc8A81D473992c7c6D3F469A8263F24914625709d": {
@@ -252,10 +185,7 @@
       "website": "https://moonli.me",
       "twitter": "https://twitter.com/moonli_me"
     },
-    "interests": [
-      "Staking",
-      "Decentralization"
-    ],
+    "interests": ["Staking", "Decentralization"],
     "description": "Moonli is an an independent staking service provider for blockchain projects. Independent means that it is run by blockchain geeks for blockchain and crypto enthusiasts just like you. No VCs or institutional support. We indeed care about keeping the stake decentralized. We pride ourselves as a boutique validator supporting networks that create real value. We have been in the staking business since 2019 and run validators on Ethereum-, Substrate- and Tendermint-based chains."
   },
   "0x067e453918f2c44D937b05a7eE9DBFB804C54ADd": {
@@ -266,10 +196,7 @@
     "links": {
       "website": "https://www.usopp.club"
     },
-    "interests": [
-      "Social Good",
-      "Reliability"
-    ],
+    "interests": ["Social Good", "Reliability"],
     "description": "Usopp is one of the genesis validators who launched the Celo blockchain on 22nd of April 2020. We have been following the Celo project since its early days in 2018. It was a privilege to witness the amazing journey of the network development from Alfajores to Baklava and the growing nascent community. The Stake-Off competition brought together a set of highly competitive but remarkably helpful and cooperatives groups of validators. Those sleepless nights of the competition have paid off really well as we are one of the 65 Genesis Validators and the grateful producer of the first block of the chain :D"
   },
   "0xE141831c2c1198d79B9Ff61cD97C3bAca7F071E0": {
@@ -281,11 +208,7 @@
       "website": "https://www.swiftstaking.com",
       "twitter": "https://twitter.com/swiftstaking"
     },
-    "interests": [
-      "The Graph",
-      "Blockchain Infrastructure",
-      "Trust"
-    ],
+    "interests": ["The Graph", "Blockchain Infrastructure", "Trust"],
     "description": "Swift staking is a validator group.  Our company is founded on the key principles of enterprise-level security, high availability, and 100% customer satisfaction. These are the reasons why stakers trust us."
   },
   "0x481EAdE762d6D0b49580189B78709c9347b395bf": {
@@ -297,11 +220,7 @@
       "website": "https://www.happycelo.com",
       "twitter": "https://twitter.com/HappyCelo_com"
     },
-    "interests": [
-      "Security",
-      "High Availability",
-      "Monitoring"
-    ],
+    "interests": ["Security", "High Availability", "Monitoring"],
     "description": "Happy Celo is your trusted Celo Validator. We have decided to use a combination of our own infrastructure and cloud services (AWS, DigitalOcean). Even-though we could have run the entire Celo infrastructure on AWS alone in our opinion it makes sense to use atleast one of the other cloud providers (Google Cloud Platform, Microsoft Azure, Digital Ocean, Linode) or your own infrastructure in case AWS will have multi region or global failure. Each set of nodes is geo-redundant by being hosted in different regions by different providers. Our own servers are hosted by a hosting provider certified in accordance with DIN ISO/IEC 27001. It also offers state of the art DDoS protection and multiple 100 GBit/s peering points on the backbone with guaranteed bandwidth of 1GBit/s."
   },
   "0x71dcC67baEECd9308e341359f70B782D9C3565b8": {
@@ -313,11 +232,7 @@
       "website": "https://virtualhive.io",
       "twitter": "https://twitter.com/VirtualHiveio"
     },
-    "interests": [
-      "Web3 Infrastructure",
-      "Reliability",
-      "Sustainability"
-    ],
+    "interests": ["Web3 Infrastructure", "Reliability", "Sustainability"],
     "description": "Virtual Hive is an organization focusing on providing infrastructure for cutting-edge technology in the web3 sector. We are passionate about new technologies, innovative economic mechanics and incentives. Our intrinsic desire to explore the unknown combined with our background in conventional enterprise best practices pave the path of our journey."
   },
   "0xB33e9e01E561a1Da60f7Cb42508500e571afb6Eb": {
@@ -329,10 +244,7 @@
       "website": "https://www.validator.capital",
       "twitter": "https://twitter.com/ValidatorCap"
     },
-    "interests": [
-      "Web3 Investment",
-      "De-Fi"
-    ],
+    "interests": ["Web3 Investment", "De-Fi"],
     "description": "Validator Capital is a Celo validator group and an active governance participant."
   },
   "0x061E9958028dcAa66fd8B255AD95194203b6c4Da": {
@@ -344,11 +256,7 @@
       "website": "https://www.easy2stake.com",
       "twitter": "https://twitter.com/easy2stake"
     },
-    "interests": [
-      "Proof-of-Stake",
-      "High Availability",
-      "Infrastructure"
-    ],
+    "interests": ["Proof-of-Stake", "High Availability", "Infrastructure"],
     "description": "Easy2Stake is a validator group on 10+ proof-of-stake chains. Our infrastructure was built with maximum security and performance at the forefront.  We provide secure, reliable, and non-custodial infrastructure so you can earn rewards."
   },
   "0xB87f2354E34B26ba6406Ac60EA99DCD8cd5e63Bf": {
@@ -360,11 +268,7 @@
       "website": "https://thepassivetrust.com",
       "twitter": "https://twitter.com/0xTPT"
     },
-    "interests": [
-      "Privacy",
-      "Prosperity",
-      "Change"
-    ],
+    "interests": ["Privacy", "Prosperity", "Change"],
     "description": "The Passive Trust provides validation and moderation services to several web3 projects. We look at where the world will be in ten years, not two."
   },
   "0xc24baeac0Fd189637112B7e33d22FfF2730aF993": {
@@ -375,11 +279,7 @@
     "links": {
       "website": "https://plusv.io"
     },
-    "interests": [
-      "Staking",
-      "Security",
-      "Passive Income"
-    ],
+    "interests": ["Staking", "Security", "Passive Income"],
     "description": "Staking is a process of delegating your cryptocurrency to us. Our valdiators are responsible for validating transactions on the blockchain. In exchange for the participation in the network, you will receive a portion of the transaction fees and block rewards that are generated on the network. This means that at the end of each validating cycle (or epoch), your stake increases, generating you passive income."
   },
   "0x070341aA5Ed571f0FB2c4a5641409B1A46b4961b": {
@@ -391,11 +291,7 @@
       "website": "https://twitter.com/franklin_dao",
       "twitter": "https://twitter.com/franklin_dao"
     },
-    "interests": [
-      "Efficiency",
-      "Growth",
-      "Impact"
-    ],
+    "interests": ["Efficiency", "Growth", "Impact"],
     "description": "FranklinDAO is a student-run DAO composing of students at the University of Pennsylvania, and is one of the most active blockchain university orgs in the world. We have made major contributions throughout the years in Uniswap, Compound, Arbitrum, Aave through working groups and spearheading proposals. We’re excited to participate in Celo and help work on impactful initiatives."
   },
   "0x12BD1596d7cfbf7c18F08499B54A31C980989070": {
@@ -407,12 +303,7 @@
       "website": "https://linktr.ee/celoorgco",
       "twitter": "https://x.com/Celo_Col"
     },
-    "interests": [
-      "Governance",
-      "ReFi",
-      "Community",
-      "StableCoins"
-    ],
+    "interests": ["Governance", "ReFi", "Community", "StableCoins"],
     "description": "Hello Celorians, we are CeloColombia 🇨🇴, dedicated to growing and supporting the Celo ecosystem in Colombia. Through our dedicated socials on X, Instagram, and Discord, we work to expand awareness and adoption of Celo across Colombia.  As CeloColombia, our mission is to foster regenerative financial solutions and strengthen Celo’s presence in the region. We are currently working on key initiatives, including stablecoin proposals and partnerships aimed at boosting liquidity within the network. Through community-building efforts and strategic governance participation, we aim to position Celo as a leader in the Latin American market and contribute to its global impact.  Let’s connect and collaborate! Find us on X and Instagram, or visit our Linktree for more."
   },
   "0x289769b63e4727616C340989E396fE69ab42Ed93": {
@@ -424,12 +315,7 @@
       "website": "https://linktr.ee/chitty_celo",
       "twitter": "https://x.com/Chittybabu7"
     },
-    "interests": [
-      "Web3",
-      "RWA",
-      "climate",
-      "finance"
-    ],
+    "interests": ["Web3", "RWA", "climate", "finance"],
     "description": "As the Celo India Lead, a Celo Ambassador, and a participant in Celo Camp and have deep commitment to building the Celo ecosystem in India. active leader in community development through organizing training sessions and meetups, while also representing Celo at conferences and hackathons across the country. Notably, won the prestigious Celo Devpost Hackathon and a key contributor to the Celo platform."
   },
   "0x3779CF289d8161Cd6679696D10647FBa2cb0ef50": {
@@ -440,12 +326,7 @@
     "links": {
       "twitter": "https://twitter.com/martinvol"
     },
-    "interests": [
-      "Engineering",
-      "Stablecoins",
-      "Latam",
-      "Europe"
-    ],
+    "interests": ["Engineering", "Stablecoins", "Latam", "Europe"],
     "description": "Have been involved in Celo since 2019, before mainnet launch. I am a Protocol Lead and director at cLabs. I'm a signer of the Celo Approver, Mento Watch and CeLatam DAO multisigs."
   },
   "0x3FB19771947072629C8EEE7995a2eF23B72d4C8A": {
@@ -457,11 +338,7 @@
       "website": "https://twitter.com/pgovteam",
       "twitter": "https://twitter.com/pgovteam"
     },
-    "interests": [
-      "Growth",
-      "Accountability",
-      "Sustainability"
-    ],
+    "interests": ["Growth", "Accountability", "Sustainability"],
     "description": "We're a team of dedicated governance enthusiasts who have been in the governance space for over four years. Our team were some of the first members involved in defi governance and we want to apply what we have learned over the years to Celo!"
   },
   "0x50111E51Cf97d6165e1A88D5CA0d4a4fa5d6c47E": {
@@ -473,13 +350,7 @@
       "website": "https://www.celodao.eu/",
       "twitter": "https://x.com/nikodcg"
     },
-    "interests": [
-      "Stablecoin",
-      "Defi",
-      "NFT",
-      "Governance",
-      "Emerging Markets"
-    ],
+    "interests": ["Stablecoin", "Defi", "NFT", "Governance", "Emerging Markets"],
     "description": "I’m originally a creative who thrives on helping builders and trailblazers find product-market fit in both business and life. Over the past two years, I’ve dedicated my energy to growing Celo’s ecosystem by leading initiatives in media, events, and opportunities that push the community forward. Becoming a delegate feels like a natural next step, allowing me to deepen my impact and serve as a voice for participants across the ecosystem."
   },
   "0x5A9dECFD5f146FCD1D1b85B2Ee069F4502fC87E4": {
@@ -491,13 +362,7 @@
       "website": "https://linktr.ee/montybryant",
       "twitter": "https://x.com/MontyMerlin"
     },
-    "interests": [
-      "ReFi",
-      "Regen",
-      "Public Goods",
-      "Environmentalism",
-      "Celo"
-    ],
+    "interests": ["ReFi", "Regen", "Public Goods", "Environmentalism", "Celo"],
     "description": "Monty is a passionate advocate for ReFi & Regeneration. He is a founder at ReFi DAO, board at Trusted Seed, co-lead at Celo Public Goods, and source, Regen Coordi-Nation."
   },
   "0x5d1ed874ea2f4269c2e1D075973c7fdb7b39154A": {
@@ -509,13 +374,7 @@
       "website": "https://www.linkedin.com/in/joan-de-ram%C3%B3n-brunet-98613b124/",
       "twitter": "https://x.com/joan_drb"
     },
-    "interests": [
-      "RWA",
-      "RWA Lending",
-      "Asset Manager",
-      "Emerging Market",
-      "Stablecoins"
-    ],
+    "interests": ["RWA", "RWA Lending", "Asset Manager", "Emerging Market", "Stablecoins"],
     "description": "Hello Celorians, this is Joan_drb. I’ve been involved with the Celo ecosystem for the past 3 years and am currently co-leading CELO EU in its second season. I started as a builder, working as Head of Growth for EthicHub, and since then I’ve developed a genuine interest in leveraging blockchain to create fair business models. My goal with Celo is to help the ecosystem by building solutions that bridge the gap between Western societies and other economies."
   },
   "0x5d36a202687fD6Bd0f670545334bF0B4827Cc1E2": {
@@ -527,11 +386,7 @@
       "website": "https://www.metricsgarden.xyz",
       "twitter": "https:/x.com/0xynamu"
     },
-    "interests": [
-      "Public Goods",
-      "Impact Assessment",
-      "Governance"
-    ],
+    "interests": ["Public Goods", "Impact Assessment", "Governance"],
     "description": "Hi! I'm LauNaMu, I deeply resonate with Celo's mission to create a more financially inclusive world through building real world onchain products and particularly cover the needs in emerging markets. Having previously worked in Fintech at the intersection of Financial Inclusion and Emerging Markets I am excited to bring this knowledge along with my experience contributing to Optimism's governance to Celo as it joins the Superchain."
   },
   "0x7811C360A5CFa1377ffdcC95b95DFD21dB0DAc06": {
@@ -542,9 +397,7 @@
     "links": {
       "twitter": "https://x.com/ivanegorov54456"
     },
-    "interests": [
-      "NFt crypto"
-    ],
+    "interests": ["NFt crypto"],
     "description": "Thai"
   },
   "0x9F444b3b4911566Dd3aE10e5e22f2e7eABef007A": {
@@ -556,12 +409,7 @@
       "website": "https://www.linkedin.com/in/mukundebrisa/",
       "twitter": "https://x.com/saint_brisa"
     },
-    "interests": [
-      "ReFi",
-      "Community",
-      "Transparency",
-      "Prosperity"
-    ],
+    "interests": ["ReFi", "Community", "Transparency", "Prosperity"],
     "description": "Hey Frens, I am dedicated to driving community growth and promoting Celo vision of a regenerative economy that benefits all. As a core contributor to the Africa DAO and an active builder in the Celo ecosystem for the past 4 years, I aim to strengthen Celo governance through inclusive decision-making. My experience in fostering Web3 communities and supporting DAO initiatives positions me to help advance Celo's development and governance."
   },
   "0x9c868c1A597d08C76406E012f6EBf44A42864D75": {
@@ -590,12 +438,7 @@
       "website": "https://wolfcito.xyz",
       "twitter": "https://x.com/AKAwolfcito"
     },
-    "interests": [
-      "Refi",
-      "Public Goods",
-      "Superchain",
-      "AI"
-    ],
+    "interests": ["Refi", "Public Goods", "Superchain", "AI"],
     "description": "I'm Wolfcito, a crypto enthusiast. I'm software developer with a strong passion for Web3. I focus on building scalable, decentralized solutions."
   },
   "0xB6Bb848A8E00b77698CAb1626C893dc8ddE4927c": {
@@ -607,13 +450,7 @@
       "website": "https://www.blaqkstereo.com",
       "twitter": "https://x.com/itshawwal"
     },
-    "interests": [
-      "Blockchain",
-      "NFTArt",
-      "Creators",
-      "Education",
-      "Decentralization"
-    ],
+    "interests": ["Blockchain", "NFTArt", "Creators", "Education", "Decentralization"],
     "description": "Founder: Blaqk Stereo Music, & Alumni Celo Camp batch 9"
   },
   "0xE73a198e7C07c418D7dcFd42f5E953074aBbD125": {
@@ -625,13 +462,7 @@
       "website": "https://urbanika.xyz/",
       "twitter": "https://twitter.com/humbertobesso"
     },
-    "interests": [
-      "Governance",
-      "IRL DAOs",
-      "Positive Planetary Impact",
-      "Commons",
-      "ReFi"
-    ],
+    "interests": ["Governance", "IRL DAOs", "Positive Planetary Impact", "Commons", "ReFi"],
     "description": "MSc & MA in eGovernance and Public Sector Innovation, 8 years in Blockchain, 10 years in IRL Community Building and Participatory Governance experiments, Founder, SolarPunk Bus driver. Delegate to me if you want to bring web3 to be used for improving your city and wellbeing."
   },
   "0xF6320E6195A816E44F9599F322D489cAbbC45D24": {
@@ -643,12 +474,7 @@
       "website": "https://motusdao.org",
       "twitter": "https://x.com/motusdao"
     },
-    "interests": [
-      "ReFi",
-      "SoFi",
-      "DeSci",
-      "Blockchain"
-    ],
+    "interests": ["ReFi", "SoFi", "DeSci", "Blockchain"],
     "description": "passionate advocate for regenerative communities and innovative Web3 solutions. With a background as a licensed psychologist, you blend expertise in mental health with decentralized technologies to drive social impact projects, including Celo Mexico, MotusDAO, ReFi Mexico."
   },
   "0xaA3600788b72863ff51C8f0dB5F10bB65fbFeAB4": {
@@ -660,13 +486,7 @@
       "website": "https://www.glodollar.org/",
       "twitter": "https://x.com/lanzdingz"
     },
-    "interests": [
-      "ReFi",
-      "DeFi",
-      "Grants",
-      "Public Goods",
-      "Stablecoins"
-    ],
+    "interests": ["ReFi", "DeFi", "Grants", "Public Goods", "Stablecoins"],
     "description": "I am a core team member and chapter lead with The GreenPill Network, as well as the Head of Growth at Glo Dollar, a stablecoin funding public goods. I serve on the Gitcoin Community Grants Council, have experience with CharmVerse's Grants Team, and am a Council member at Octant and an ambassador for Unlock Protocol. With a strong background in DAOs and community building, I bring expertise in governance and network development, and I am committed to advocating for collaborative solutions to global challenges."
   },
   "0xbd7b5d8Fdc2d21e73350741ff5C4cAC335B219a2": {
@@ -678,11 +498,7 @@
       "website": "https://celomexico.org/",
       "twitter": "https://x.com/celomexico"
     },
-    "interests": [
-      "Blockchain",
-      "ReFi",
-      "SoFi"
-    ],
+    "interests": ["Blockchain", "ReFi", "SoFi"],
     "description": "Regional Celo DAO in Mexico"
   },
   "0xe486E4F9c7efd40B999DfAD946407612c4a56C1B": {
@@ -693,9 +509,7 @@
     "links": {
       "twitter": "https://twitter.com/ezema_precious?s=21&t=8D9qM7gef6Imbd_8bublNg"
     },
-    "interests": [
-      "DAO Governance"
-    ],
+    "interests": ["DAO Governance"],
     "description": "Precious Ezema is a community builder with over 5 years experience. She has adept experience building blockchain communities. She constantly advocates for women in web3 and have worked with blockchain companies, like Celo, ethereum and Solana"
   },
   "0x2AeD14FE7bd056212cD0eD91b57a8EC5A5E33624": {
@@ -707,12 +521,7 @@
       "website": "https://linktr.ee/ricaax",
       "twitter": "https://www.twitter.com/ricaa"
     },
-    "interests": [
-      "ReFi",
-      "Public Goods",
-      "Educational Programs",
-      "Ecosystem Development"
-    ],
+    "interests": ["ReFi", "Public Goods", "Educational Programs", "Ecosystem Development"],
     "description": "Hi folks, this is Rica. I’ve been involved with Celo in one way or another for over 2 years already. I co-founded PositiveBlockchain.io and ReFi Lisboa, and I'm  the host of planta-R, the Portuguese ReFi podcast. Recently, I stepped into the Marketing Lead role for Celo EU’s 2nd season.  As a creative strategist and marketer with over a decade of experience at the intersection of business, art, tech, and impact, I focus on projects that uphold civil liberties, champion equality, nurture democratic values, and safeguard our planet’s future. I’m driven by a belief in the power of collective intelligence and decentralized communities to create meaningful change."
   },
   "0x2aa64E6d80390F5C017F0313cB908051BE2FD35e": {
@@ -724,12 +533,7 @@
       "website": "https://afolabi.info",
       "twitter": "https://twitter.com/time_is_oba"
     },
-    "interests": [
-      "Public Goods",
-      "Blockchains",
-      "Augmented Reality",
-      "Music"
-    ],
+    "interests": ["Public Goods", "Blockchains", "Augmented Reality", "Music"],
     "description": "Builder and Steward helping craft the foundations of the regen space with Greenpill & WEFA"
   },
   "0x31bCfe0836492224C71410D62d4e0532ca128B3c": {
@@ -741,11 +545,7 @@
       "website": "https://x.com/frerehugi",
       "twitter": "https://x.com/frerehugi"
     },
-    "interests": [
-      "stablecoin usage",
-      "trading",
-      "CELO in East Africa"
-    ],
+    "interests": ["stablecoin usage", "trading", "CELO in East Africa"],
     "description": "Surgeon with passion for CELO"
   },
   "0x37BAedAA536f7144E72915C683e6095177D33e78": {
@@ -775,9 +575,7 @@
       "website": "https://x.com/Slava738599",
       "twitter": "https://x.com/Slava738599"
     },
-    "interests": [
-      "web"
-    ],
+    "interests": ["web"],
     "description": "delegation"
   },
   "0x809C9f8dd8CA93A41c3adca4972Fa234C28F7714": {
@@ -788,11 +586,7 @@
     "links": {
       "twitter": "https://twitter.com/paul_glavin"
     },
-    "interests": [
-      "Decision mechanisms",
-      "public goods funding",
-      "community governance"
-    ],
+    "interests": ["Decision mechanisms", "public goods funding", "community governance"],
     "description": "building better money 🌱 Open Source Project Lead for gardens.fund"
   },
   "0x1421d52714B01298E2e9AA969e14c9317B3E1CFA": {
@@ -804,11 +598,7 @@
       "website": "https://allo.capital/",
       "twitter": "https://x.com/sejal_rekhan"
     },
-    "interests": [
-      "Public Goods Funding",
-      "AI",
-      "Governance"
-    ],
+    "interests": ["Public Goods Funding", "AI", "Governance"],
     "description": "Hi! I’m Sejal. I started my journey at Gitcoin, where I focused on community-driven grants and collaborative funding, and I’m now at Allo Capital exploring innovative funding mechanisms. I’m passionate about making Celo a hub for public goods, testing and building mechanisms that benefit everyone.  As a Celo PG Steward, I’m excited to bring my experience in PGF to support Celo’s mission."
   },
   "0x2f9B1BEDCbF3F2E060806b96d519f6261e6Fce13": {
@@ -820,11 +610,7 @@
       "website": "http://github.com/emiridbest",
       "twitter": "http://x.com/emiridbest"
     },
-    "interests": [
-      "Defi",
-      "Stablecoin",
-      "DeSci"
-    ],
+    "interests": ["Defi", "Stablecoin", "DeSci"],
     "description": "Founder @Esusu, ex Celo Camp Batch9, ex sage,  multiple hackathon winning."
   },
   "0x5670daa9De464782b7B6fc88E659F079aE7C2f94": {
@@ -872,13 +658,7 @@
       "website": "https://handprotocol.org",
       "twitter": "https://x.com/crypto_koh"
     },
-    "interests": [
-      "Gov",
-      "Regen",
-      "Art",
-      "AI",
-      "OSS"
-    ],
+    "interests": ["Gov", "Regen", "Art", "AI", "OSS"],
     "description": "Hey I'm koH and my main focus is leveraging blockchain to help positive change projects. My main project is Hand Protocol which is focused on assisting regen projects or people to accomplish their missions!"
   },
   "0x1d8b86f4E261b6329465358f573c3B31A4a2A646": {
@@ -890,13 +670,7 @@
       "website": "https://marieclairegraf.com",
       "twitter": "https://x.com/MarieClaireGraf"
     },
-    "interests": [
-      "climate",
-      "diplomacy",
-      "negotiations",
-      "nature",
-      "sailing"
-    ],
+    "interests": ["climate", "diplomacy", "negotiations", "nature", "sailing"],
     "description": "Co-Founder of Youth Negotiators Academy for democratic governance and intergenerational leadership in environmental policy, diplomacy and decision-making processes to create a momentum for systemic change. She was initiating and is leading several associations and movements on the intersections of climate, youth and women representation, food systems transformation and education. She studied environmental and political sciences in Zurich and was a climate negotiator for Switzerland."
   },
   "0x20F50b8832f87104853df3FdDA47Dd464f885a49": {
@@ -908,11 +682,7 @@
       "website": "https://philix.vercel.app",
       "twitter": "https://x.com/philixbob"
     },
-    "interests": [
-      "Stablecoin",
-      "Defi",
-      "Impact"
-    ],
+    "interests": ["Stablecoin", "Defi", "Impact"],
     "description": "Software developer and Founder @pharmoprep"
   },
   "0x3DDC7d25c7a1dc381443e491Bbf1Caa8928A05B0": {
@@ -923,12 +693,7 @@
     "links": {
       "twitter": "https://x.com/DefiIgnas"
     },
-    "interests": [
-      "DeFi",
-      "L1s",
-      "L2s",
-      "DAO governance"
-    ],
+    "interests": ["DeFi", "L1s", "L2s", "DAO governance"],
     "description": "I’m Ignas, a solo researcher with the main focus on DeFi. My mission is to provide clear, in-depth insights helping my audiences stay up-to-date with the latest trends while actively supporting DAO development.  I believe in the decentralized future and it means actively participating in Arbitrum DAO in every way I can—whether it’s by serving as a delegate, joining working groups, discussing any proposals or seizing new opportunities that come up. I’ll also be sharing key DAO decisions on X and my blog."
   },
   "0x5523058cdFfe5F3c1EaDADD5015E55C6E00fb439": {
@@ -940,13 +705,7 @@
       "website": "https://grassrootseconomics.org",
       "twitter": "https://x.com/grassecon"
     },
-    "interests": [
-      "Open Source",
-      "Governance",
-      "ReFi",
-      "Community",
-      "Engineering"
-    ],
+    "interests": ["Open Source", "Governance", "ReFi", "Community", "Engineering"],
     "description": "Grassroots Economics is a non-profit foundation that seeks to support communities to take charge of their own livelihoods and economic future. We focus on community development through commons and are dedicated to helping communities realize and share their abundance through Economic Commons with Instruments like Community Asset Vouchers and Commitment Pooling that can act as a medium of exchange and commons. While core beneficiaries of our programs include businesses and people living in informal settlements as well as rural areas, the documentation and tools have been broadly applied worldwide.  It is tremendously important to us that people take, use, build on and share what we've found to be useful. Join us in demonstrating, disseminating, designing & curating the best practices to empower communities to create and manage their own financial instruments. All our software, websites, materials are CopyLeft under AGPL 3.0 for software and Creative Commons Share-Alike With Attribution. Please copy, modify and"
   },
   "0x6820442229778647b77cA1bb1746d1966dEbe3Ea": {
@@ -958,10 +717,7 @@
       "website": "https://x.com/VowIMTX",
       "twitter": "https://x.com/VowIMTX"
     },
-    "interests": [
-      "Blockchain",
-      "Sustainable"
-    ],
+    "interests": ["Blockchain", "Sustainable"],
     "description": "Advisor at KohCelo"
   },
   "0xCDaba8e196D9BF1DabdF6b5D3Bc3BFD175FF81c8": {
@@ -973,9 +729,7 @@
       "website": "https://www.umnbc.org/",
       "twitter": "https://x.com/umnblockchain"
     },
-    "interests": [
-      "Blockchain"
-    ],
+    "interests": ["Blockchain"],
     "description": "Club at University of Minnesota dedicated to Blockchain"
   },
   "0xba3982536F79090D4d68cD14e1B7d15fF1014030": {
@@ -986,12 +740,7 @@
     "links": {
       "twitter": "https://x.com/ndukaanthonya"
     },
-    "interests": [
-      "Community",
-      "NFTs",
-      "DAO",
-      "Stablecoins"
-    ],
+    "interests": ["Community", "NFTs", "DAO", "Stablecoins"],
     "description": "Community Developer"
   },
   "0xcFB5a8A167c1E437e34d82C25Cc0Ef24d4f27d4b": {
@@ -1003,9 +752,7 @@
       "website": "https://blockchain.studentorg.berkeley.edu/",
       "twitter": "https://x.com/CalBlockchain"
     },
-    "interests": [
-      "Blockchain"
-    ],
+    "interests": ["Blockchain"],
     "description": "Student Organization at Berkeley focused on blockchain innovation, education, consulting, and research. Founded in 2014."
   }
 }

--- a/src/config/delegates.json
+++ b/src/config/delegates.json
@@ -8,7 +8,13 @@
       "website": "https://forum.celo.org/u/pcbo/summary",
       "twitter": "https://x.com/pcbo"
     },
-    "interests": ["SocialFi", "Reputation", "Identity", "Public Goods", "Superchain"],
+    "interests": [
+      "SocialFi",
+      "Reputation",
+      "Identity",
+      "Public Goods",
+      "Superchain"
+    ],
     "description": "Considering my Celo Public Goods 2024 H2 Steward role is coming to an end, I want to continue to give-back to the Celo community now as a outspoken Delegate. I believe that I bring an unique POV as a Delegate based on my experience as a multi-startup founder, unique HR Tech builder background, bear-market survivor builder making the rounds over at Talent Protocol to build a new better reputation engine for professional work."
   },
   "0x3e737AD3234a127066043D5Df2ABF7adDEC79c2b": {
@@ -19,7 +25,12 @@
     "links": {
       "website": "https://forum.celo.org/u/0xgoldo/summary"
     },
-    "interests": ["Community", "Defi", "Decentralization", "Transparency"],
+    "interests": [
+      "Community",
+      "Defi",
+      "Decentralization",
+      "Transparency"
+    ],
     "description": "Hi Celorians! I am a member of the Celo Guardians team (formerly known as 'CGP Editors'), the decentralized working group that is helping to mantain and organize the Celo Governance. I am also part of the Moderators team, a role that require myself to be involved and up to date around everything happening on Celo and his ecosystem. As a Celo Delegate, my motivation is rooted in the desire to support a decentralized, inclusive, and environmentally conscious financial ecosystem. I believe in Celo’s mission to bring prosperity to all by leveraging blockchain technology, particularly in providing financial tools to underserved communities globally."
   },
   "0x8b37a5Af68D315cf5A64097D96621F64b5502a22": {
@@ -31,7 +42,11 @@
       "website": "https://www.areta.io/",
       "twitter": "https://x.com/areta_io"
     },
-    "interests": ["Governance Design", "Ecosystem Growth", "Decentralization"],
+    "interests": [
+      "Governance Design",
+      "Ecosystem Growth",
+      "Decentralization"
+    ],
     "description": "Areta Governance specializes in supporting DAOs and foundations to establish and grow decentralized governance structures. We develop tailored solutions in governance inception and optimization, ecosystem growth, and service provider selection. Our connected investment bank with deep strategic expertise, enables us to serve our partners holistically, rather than working in isolated governance silos. ​We have had the privilege to work alongside industry leaders such as Uniswap, Arbitrum, Safe, Aave, and dYdX."
   },
   "0x3c3Eb5C41720D555F81eD554e901edD0a6aF228C": {
@@ -43,7 +58,12 @@
       "website": "https://www.stake.capital/",
       "twitter": "https://x.com/StakeCapital"
     },
-    "interests": ["Proof-of-Stake", "High Availability", "Infrastructure", "Web3 Investment"],
+    "interests": [
+      "Proof-of-Stake",
+      "High Availability",
+      "Infrastructure",
+      "Web3 Investment"
+    ],
     "description": "Stake Capital is a trusted and experienced blockchain investment firm, actively contributing to the blockchain ecosystem since 2016. With expertise in venture capital, incubation, acceleration, and validation, we ensure robust participation in governance through our mainnet validation for top projects and our involvement in testnets for emerging infrastructures. Our commitment to excellence and transparency makes us a reliable partner to delegate your voting power, helping to secure and innovate within the Celo network."
   },
   "0x2D7d6Ec6198ADFD5850D00BD601958F6E316b05E": {
@@ -68,7 +88,12 @@
     "logoUri": "/logos/delegatees/oliseh.jpg",
     "date": "2024-05-09",
     "links": {},
-    "interests": ["Discovery", "Engaged", "Calm", "Love"],
+    "interests": [
+      "Discovery",
+      "Engaged",
+      "Calm",
+      "Love"
+    ],
     "description": "Oliseh is unbaised , belives in Celo and more so a passive builder. Got into the Celo ecosystem through Celo Africa Dao but everyday building new products for the ecosystem"
   },
   "0x657D07095b082BB71ebD93F549f407A97f49094F": {
@@ -79,7 +104,12 @@
     "links": {
       "twitter": "https://twitter.com/0xMims"
     },
-    "interests": ["DAO Design", "Fitness", "Language Learning", "Cooking"],
+    "interests": [
+      "DAO Design",
+      "Fitness",
+      "Language Learning",
+      "Cooking"
+    ],
     "description": "I’ve been committed to the crypto ecosystem for about three years now. I had my start with FranklinDAO/Penn Blockchain on its research committee. Since graduating a few months ago, I’ve been honored to be welcomed into the Blockworks team on their protocol services wing. I am currently representing Blockworks across multiple DAOs and we perform applied research to help push DAOs into new directions. To be explicit though, my interest in Celo is personal, not occupational, and I seek to help expand Celo’s regeneration initiative and help enforce its public-goods identity. While I have no prior forum history, I certainly have the background and history that would describe me as a long-term participant."
   },
   "0x720c293071a9e084c3A8c82F42c98065Be546FcC": {
@@ -90,7 +120,12 @@
     "links": {
       "twitter": "https://twitter.com/xlzy905"
     },
-    "interests": ["Technology", "Development", "Community", "Innovation"],
+    "interests": [
+      "Technology",
+      "Development",
+      "Community",
+      "Innovation"
+    ],
     "description": "Hello, Celo Community! I am an experienced web3 developer deeply committed to the Celo ecosystem. With a strong background in blockchain technology and a passion for innovative solutions, I've been actively contributing to various web3 projects. I firmly believe in Celo's vision of creating a more accessible and inclusive financial system. My goal is to contribute to Celo's growth while ensuring that our decisions align with the best interests of both the technology and the community it serves."
   },
   "0x31cd90C2788f3e390d2Bb72871f5aD3F1a4B22a1": {
@@ -102,7 +137,13 @@
       "website": "https://forum.celo.org/t/steward-thread-luukdao/7460",
       "twitter": "https://twitter.com/LuukDAO"
     },
-    "interests": ["ReFi", "Stablecoins", "DeFi", "Public Goods", "Superchain"],
+    "interests": [
+      "ReFi",
+      "Stablecoins",
+      "DeFi",
+      "Public Goods",
+      "Superchain"
+    ],
     "description": "I’m committed entirely to enabling Regeneration at scale and wholeheartedly believe Celo’s vision to build a digital economy that creates conditions for all is a foundation required to realize my mission. As a Celo Builder, I want to support Celo’s development and good governance, and believe my experience as a Web3 delegate and founder can help progress Celo. I have 5+ years of experience participating in leading DAOs, including PrimeDAO, BalancerDAO, SafeDAO, and Optimism."
   },
   "0xC20F4412fa84b33e0f3657113736F229a811A285": {
@@ -113,7 +154,12 @@
     "links": {
       "twitter": "https://twitter.com/_iamoracle"
     },
-    "interests": ["Community", "Transparency", "Accountability", "Good Vibes"],
+    "interests": [
+      "Community",
+      "Transparency",
+      "Accountability",
+      "Good Vibes"
+    ],
     "description": "Hello, Community! I am a developer, a 6x Hackathon winner (of which 4 are Celo-organized) and a founder within the Celo Ecosystem. I have previously served as a DevRel Community Moderator, and I have been supporting developers across the ecosystem. I am willing to use my experience to help review technical proposals and vote accordingly in the governance process."
   },
   "0xFEF5A1A2b3754A2F53161EaaAcb3EB889F004d4a": {
@@ -125,7 +171,12 @@
       "website": "https://linktr.ee/0xj4an_work",
       "twitter": "https://twitter.com/0xj4an"
     },
-    "interests": ["Community", "Transparency", "Accountability", "Good Vibes"],
+    "interests": [
+      "Community",
+      "Transparency",
+      "Accountability",
+      "Good Vibes"
+    ],
     "description": "Hey, I am a member of the Celo Guardians (formerly known as 'CGP Editors'). I help maintain the history of governance proposals and am an active contributor to the Celo community."
   },
   "0xd42Bb7FE32cDf68045f49553c6f851fD2c58B6a9": {
@@ -137,7 +188,13 @@
       "website": "https://linktr.ee/reficolombia",
       "twitter": "https://twitter.com/reficolombia"
     },
-    "interests": ["ReFi", "Community", "Transparency", "Accountability", "Good Vibes"],
+    "interests": [
+      "ReFi",
+      "Community",
+      "Transparency",
+      "Accountability",
+      "Good Vibes"
+    ],
     "description": "Our mission is clear, we commit to allocating all of our validator gains towards empowering the ReFi movement in Colombia and supporting individuals in need. Our dedication goes beyond securing the network; we are determined to leverage all of our gains to support the ReFi movement in Colombia.🇨🇴"
   },
   "0xFaa0b40645Ee5E8D9AE38393e8cDF8e5baA71d13": {
@@ -149,7 +206,10 @@
       "website": "https://staking.fund",
       "twitter": "https://twitter.com/stakingfund"
     },
-    "interests": ["Proof-of-Stake", "Infrastructure"],
+    "interests": [
+      "Proof-of-Stake",
+      "Infrastructure"
+    ],
     "description": "Staking Fund operates block producing validation nodes on Proof-of-Stake protocols.  We've been actively engaging in the validating role for numerous novel Proof-of-Stake protocols since 2018 and proving our commitment to secure decentralized blockchain networks with high availability and zero slashing."
   },
   "0xD72Ed2e3db984bAC3bB351FE652200dE527eFfcf": {
@@ -161,7 +221,11 @@
       "website": "https://chainvibes.com/decloud.html",
       "twitter": "https://twitter.com/chain_vibes"
     },
-    "interests": ["Transparency", "Accountability", "Good Vibes"],
+    "interests": [
+      "Transparency",
+      "Accountability",
+      "Good Vibes"
+    ],
     "description": "Chain vibes is a validator group. We are transparent about our on-chain governance decision making as well as our commission change rate schedule. Our whole live is about IT engineering, now we take this opportunity to keep the vibe in the chain"
   },
   "0x0339Df3FE4f5ccC864EAE8491E5c8AEc4611A631": {
@@ -173,7 +237,10 @@
       "website": "https://tessellated.io",
       "twitter": "https://twitter.com/tessellated_io"
     },
-    "interests": ["Proof-of-Stake", "Infrastructure"],
+    "interests": [
+      "Proof-of-Stake",
+      "Infrastructure"
+    ],
     "description": "Tessellated is an independent and technically capable validator. Tessellated has validated and contributed to networks since 2018."
   },
   "0xc8A81D473992c7c6D3F469A8263F24914625709d": {
@@ -185,7 +252,10 @@
       "website": "https://moonli.me",
       "twitter": "https://twitter.com/moonli_me"
     },
-    "interests": ["Staking", "Decentralization"],
+    "interests": [
+      "Staking",
+      "Decentralization"
+    ],
     "description": "Moonli is an an independent staking service provider for blockchain projects. Independent means that it is run by blockchain geeks for blockchain and crypto enthusiasts just like you. No VCs or institutional support. We indeed care about keeping the stake decentralized. We pride ourselves as a boutique validator supporting networks that create real value. We have been in the staking business since 2019 and run validators on Ethereum-, Substrate- and Tendermint-based chains."
   },
   "0x067e453918f2c44D937b05a7eE9DBFB804C54ADd": {
@@ -196,7 +266,10 @@
     "links": {
       "website": "https://www.usopp.club"
     },
-    "interests": ["Social Good", "Reliability"],
+    "interests": [
+      "Social Good",
+      "Reliability"
+    ],
     "description": "Usopp is one of the genesis validators who launched the Celo blockchain on 22nd of April 2020. We have been following the Celo project since its early days in 2018. It was a privilege to witness the amazing journey of the network development from Alfajores to Baklava and the growing nascent community. The Stake-Off competition brought together a set of highly competitive but remarkably helpful and cooperatives groups of validators. Those sleepless nights of the competition have paid off really well as we are one of the 65 Genesis Validators and the grateful producer of the first block of the chain :D"
   },
   "0xE141831c2c1198d79B9Ff61cD97C3bAca7F071E0": {
@@ -208,7 +281,11 @@
       "website": "https://www.swiftstaking.com",
       "twitter": "https://twitter.com/swiftstaking"
     },
-    "interests": ["The Graph", "Blockchain Infrastructure", "Trust"],
+    "interests": [
+      "The Graph",
+      "Blockchain Infrastructure",
+      "Trust"
+    ],
     "description": "Swift staking is a validator group.  Our company is founded on the key principles of enterprise-level security, high availability, and 100% customer satisfaction. These are the reasons why stakers trust us."
   },
   "0x481EAdE762d6D0b49580189B78709c9347b395bf": {
@@ -220,7 +297,11 @@
       "website": "https://www.happycelo.com",
       "twitter": "https://twitter.com/HappyCelo_com"
     },
-    "interests": ["Security", "High Availability", "Monitoring"],
+    "interests": [
+      "Security",
+      "High Availability",
+      "Monitoring"
+    ],
     "description": "Happy Celo is your trusted Celo Validator. We have decided to use a combination of our own infrastructure and cloud services (AWS, DigitalOcean). Even-though we could have run the entire Celo infrastructure on AWS alone in our opinion it makes sense to use atleast one of the other cloud providers (Google Cloud Platform, Microsoft Azure, Digital Ocean, Linode) or your own infrastructure in case AWS will have multi region or global failure. Each set of nodes is geo-redundant by being hosted in different regions by different providers. Our own servers are hosted by a hosting provider certified in accordance with DIN ISO/IEC 27001. It also offers state of the art DDoS protection and multiple 100 GBit/s peering points on the backbone with guaranteed bandwidth of 1GBit/s."
   },
   "0x71dcC67baEECd9308e341359f70B782D9C3565b8": {
@@ -232,7 +313,11 @@
       "website": "https://virtualhive.io",
       "twitter": "https://twitter.com/VirtualHiveio"
     },
-    "interests": ["Web3 Infrastructure", "Reliability", "Sustainability"],
+    "interests": [
+      "Web3 Infrastructure",
+      "Reliability",
+      "Sustainability"
+    ],
     "description": "Virtual Hive is an organization focusing on providing infrastructure for cutting-edge technology in the web3 sector. We are passionate about new technologies, innovative economic mechanics and incentives. Our intrinsic desire to explore the unknown combined with our background in conventional enterprise best practices pave the path of our journey."
   },
   "0xB33e9e01E561a1Da60f7Cb42508500e571afb6Eb": {
@@ -244,7 +329,10 @@
       "website": "https://www.validator.capital",
       "twitter": "https://twitter.com/ValidatorCap"
     },
-    "interests": ["Web3 Investment", "De-Fi"],
+    "interests": [
+      "Web3 Investment",
+      "De-Fi"
+    ],
     "description": "Validator Capital is a Celo validator group and an active governance participant."
   },
   "0x061E9958028dcAa66fd8B255AD95194203b6c4Da": {
@@ -256,7 +344,11 @@
       "website": "https://www.easy2stake.com",
       "twitter": "https://twitter.com/easy2stake"
     },
-    "interests": ["Proof-of-Stake", "High Availability", "Infrastructure"],
+    "interests": [
+      "Proof-of-Stake",
+      "High Availability",
+      "Infrastructure"
+    ],
     "description": "Easy2Stake is a validator group on 10+ proof-of-stake chains. Our infrastructure was built with maximum security and performance at the forefront.  We provide secure, reliable, and non-custodial infrastructure so you can earn rewards."
   },
   "0xB87f2354E34B26ba6406Ac60EA99DCD8cd5e63Bf": {
@@ -268,7 +360,11 @@
       "website": "https://thepassivetrust.com",
       "twitter": "https://twitter.com/0xTPT"
     },
-    "interests": ["Privacy", "Prosperity", "Change"],
+    "interests": [
+      "Privacy",
+      "Prosperity",
+      "Change"
+    ],
     "description": "The Passive Trust provides validation and moderation services to several web3 projects. We look at where the world will be in ten years, not two."
   },
   "0xc24baeac0Fd189637112B7e33d22FfF2730aF993": {
@@ -279,7 +375,11 @@
     "links": {
       "website": "https://plusv.io"
     },
-    "interests": ["Staking", "Security", "Passive Income"],
+    "interests": [
+      "Staking",
+      "Security",
+      "Passive Income"
+    ],
     "description": "Staking is a process of delegating your cryptocurrency to us. Our valdiators are responsible for validating transactions on the blockchain. In exchange for the participation in the network, you will receive a portion of the transaction fees and block rewards that are generated on the network. This means that at the end of each validating cycle (or epoch), your stake increases, generating you passive income."
   },
   "0x070341aA5Ed571f0FB2c4a5641409B1A46b4961b": {
@@ -291,7 +391,11 @@
       "website": "https://twitter.com/franklin_dao",
       "twitter": "https://twitter.com/franklin_dao"
     },
-    "interests": ["Efficiency", "Growth", "Impact"],
+    "interests": [
+      "Efficiency",
+      "Growth",
+      "Impact"
+    ],
     "description": "FranklinDAO is a student-run DAO composing of students at the University of Pennsylvania, and is one of the most active blockchain university orgs in the world. We have made major contributions throughout the years in Uniswap, Compound, Arbitrum, Aave through working groups and spearheading proposals. We’re excited to participate in Celo and help work on impactful initiatives."
   },
   "0x12BD1596d7cfbf7c18F08499B54A31C980989070": {
@@ -303,7 +407,12 @@
       "website": "https://linktr.ee/celoorgco",
       "twitter": "https://x.com/Celo_Col"
     },
-    "interests": ["Governance", "ReFi", "Community", "StableCoins"],
+    "interests": [
+      "Governance",
+      "ReFi",
+      "Community",
+      "StableCoins"
+    ],
     "description": "Hello Celorians, we are CeloColombia 🇨🇴, dedicated to growing and supporting the Celo ecosystem in Colombia. Through our dedicated socials on X, Instagram, and Discord, we work to expand awareness and adoption of Celo across Colombia.  As CeloColombia, our mission is to foster regenerative financial solutions and strengthen Celo’s presence in the region. We are currently working on key initiatives, including stablecoin proposals and partnerships aimed at boosting liquidity within the network. Through community-building efforts and strategic governance participation, we aim to position Celo as a leader in the Latin American market and contribute to its global impact.  Let’s connect and collaborate! Find us on X and Instagram, or visit our Linktree for more."
   },
   "0x289769b63e4727616C340989E396fE69ab42Ed93": {
@@ -315,7 +424,12 @@
       "website": "https://linktr.ee/chitty_celo",
       "twitter": "https://x.com/Chittybabu7"
     },
-    "interests": ["Web3", "RWA", "climate", "finance"],
+    "interests": [
+      "Web3",
+      "RWA",
+      "climate",
+      "finance"
+    ],
     "description": "As the Celo India Lead, a Celo Ambassador, and a participant in Celo Camp and have deep commitment to building the Celo ecosystem in India. active leader in community development through organizing training sessions and meetups, while also representing Celo at conferences and hackathons across the country. Notably, won the prestigious Celo Devpost Hackathon and a key contributor to the Celo platform."
   },
   "0x3779CF289d8161Cd6679696D10647FBa2cb0ef50": {
@@ -326,7 +440,12 @@
     "links": {
       "twitter": "https://twitter.com/martinvol"
     },
-    "interests": ["Engineering", "Stablecoins", "Latam", "Europe"],
+    "interests": [
+      "Engineering",
+      "Stablecoins",
+      "Latam",
+      "Europe"
+    ],
     "description": "Have been involved in Celo since 2019, before mainnet launch. I am a Protocol Lead and director at cLabs. I'm a signer of the Celo Approver, Mento Watch and CeLatam DAO multisigs."
   },
   "0x3FB19771947072629C8EEE7995a2eF23B72d4C8A": {
@@ -338,7 +457,11 @@
       "website": "https://twitter.com/pgovteam",
       "twitter": "https://twitter.com/pgovteam"
     },
-    "interests": ["Growth", "Accountability", "Sustainability"],
+    "interests": [
+      "Growth",
+      "Accountability",
+      "Sustainability"
+    ],
     "description": "We're a team of dedicated governance enthusiasts who have been in the governance space for over four years. Our team were some of the first members involved in defi governance and we want to apply what we have learned over the years to Celo!"
   },
   "0x50111E51Cf97d6165e1A88D5CA0d4a4fa5d6c47E": {
@@ -350,7 +473,13 @@
       "website": "https://www.celodao.eu/",
       "twitter": "https://x.com/nikodcg"
     },
-    "interests": ["Stablecoin", "Defi", "NFT", "Governance", "Emerging Markets"],
+    "interests": [
+      "Stablecoin",
+      "Defi",
+      "NFT",
+      "Governance",
+      "Emerging Markets"
+    ],
     "description": "I’m originally a creative who thrives on helping builders and trailblazers find product-market fit in both business and life. Over the past two years, I’ve dedicated my energy to growing Celo’s ecosystem by leading initiatives in media, events, and opportunities that push the community forward. Becoming a delegate feels like a natural next step, allowing me to deepen my impact and serve as a voice for participants across the ecosystem."
   },
   "0x5A9dECFD5f146FCD1D1b85B2Ee069F4502fC87E4": {
@@ -362,7 +491,13 @@
       "website": "https://linktr.ee/montybryant",
       "twitter": "https://x.com/MontyMerlin"
     },
-    "interests": ["ReFi", "Regen", "Public Goods", "Environmentalism", "Celo"],
+    "interests": [
+      "ReFi",
+      "Regen",
+      "Public Goods",
+      "Environmentalism",
+      "Celo"
+    ],
     "description": "Monty is a passionate advocate for ReFi & Regeneration. He is a founder at ReFi DAO, board at Trusted Seed, co-lead at Celo Public Goods, and source, Regen Coordi-Nation."
   },
   "0x5d1ed874ea2f4269c2e1D075973c7fdb7b39154A": {
@@ -374,7 +509,13 @@
       "website": "https://www.linkedin.com/in/joan-de-ram%C3%B3n-brunet-98613b124/",
       "twitter": "https://x.com/joan_drb"
     },
-    "interests": ["RWA", "RWA Lending", "Asset Manager", "Emerging Market", "Stablecoins"],
+    "interests": [
+      "RWA",
+      "RWA Lending",
+      "Asset Manager",
+      "Emerging Market",
+      "Stablecoins"
+    ],
     "description": "Hello Celorians, this is Joan_drb. I’ve been involved with the Celo ecosystem for the past 3 years and am currently co-leading CELO EU in its second season. I started as a builder, working as Head of Growth for EthicHub, and since then I’ve developed a genuine interest in leveraging blockchain to create fair business models. My goal with Celo is to help the ecosystem by building solutions that bridge the gap between Western societies and other economies."
   },
   "0x5d36a202687fD6Bd0f670545334bF0B4827Cc1E2": {
@@ -386,7 +527,11 @@
       "website": "https://www.metricsgarden.xyz",
       "twitter": "https:/x.com/0xynamu"
     },
-    "interests": ["Public Goods", "Impact Assessment", "Governance"],
+    "interests": [
+      "Public Goods",
+      "Impact Assessment",
+      "Governance"
+    ],
     "description": "Hi! I'm LauNaMu, I deeply resonate with Celo's mission to create a more financially inclusive world through building real world onchain products and particularly cover the needs in emerging markets. Having previously worked in Fintech at the intersection of Financial Inclusion and Emerging Markets I am excited to bring this knowledge along with my experience contributing to Optimism's governance to Celo as it joins the Superchain."
   },
   "0x7811C360A5CFa1377ffdcC95b95DFD21dB0DAc06": {
@@ -397,7 +542,9 @@
     "links": {
       "twitter": "https://x.com/ivanegorov54456"
     },
-    "interests": ["NFt crypto"],
+    "interests": [
+      "NFt crypto"
+    ],
     "description": "Thai"
   },
   "0x9F444b3b4911566Dd3aE10e5e22f2e7eABef007A": {
@@ -409,7 +556,12 @@
       "website": "https://www.linkedin.com/in/mukundebrisa/",
       "twitter": "https://x.com/saint_brisa"
     },
-    "interests": ["ReFi", "Community", "Transparency", "Prosperity"],
+    "interests": [
+      "ReFi",
+      "Community",
+      "Transparency",
+      "Prosperity"
+    ],
     "description": "Hey Frens, I am dedicated to driving community growth and promoting Celo vision of a regenerative economy that benefits all. As a core contributor to the Africa DAO and an active builder in the Celo ecosystem for the past 4 years, I aim to strengthen Celo governance through inclusive decision-making. My experience in fostering Web3 communities and supporting DAO initiatives positions me to help advance Celo's development and governance."
   },
   "0x9c868c1A597d08C76406E012f6EBf44A42864D75": {
@@ -438,7 +590,12 @@
       "website": "https://wolfcito.xyz",
       "twitter": "https://x.com/AKAwolfcito"
     },
-    "interests": ["Refi", "Public Goods", "Superchain", "AI"],
+    "interests": [
+      "Refi",
+      "Public Goods",
+      "Superchain",
+      "AI"
+    ],
     "description": "I'm Wolfcito, a crypto enthusiast. I'm software developer with a strong passion for Web3. I focus on building scalable, decentralized solutions."
   },
   "0xB6Bb848A8E00b77698CAb1626C893dc8ddE4927c": {
@@ -450,7 +607,13 @@
       "website": "https://www.blaqkstereo.com",
       "twitter": "https://x.com/itshawwal"
     },
-    "interests": ["Blockchain", "NFTArt", "Creators", "Education", "Decentralization"],
+    "interests": [
+      "Blockchain",
+      "NFTArt",
+      "Creators",
+      "Education",
+      "Decentralization"
+    ],
     "description": "Founder: Blaqk Stereo Music, & Alumni Celo Camp batch 9"
   },
   "0xE73a198e7C07c418D7dcFd42f5E953074aBbD125": {
@@ -462,7 +625,13 @@
       "website": "https://urbanika.xyz/",
       "twitter": "https://twitter.com/humbertobesso"
     },
-    "interests": ["Governance", "IRL DAOs", "Positive Planetary Impact", "Commons", "ReFi"],
+    "interests": [
+      "Governance",
+      "IRL DAOs",
+      "Positive Planetary Impact",
+      "Commons",
+      "ReFi"
+    ],
     "description": "MSc & MA in eGovernance and Public Sector Innovation, 8 years in Blockchain, 10 years in IRL Community Building and Participatory Governance experiments, Founder, SolarPunk Bus driver. Delegate to me if you want to bring web3 to be used for improving your city and wellbeing."
   },
   "0xF6320E6195A816E44F9599F322D489cAbbC45D24": {
@@ -474,7 +643,12 @@
       "website": "https://motusdao.org",
       "twitter": "https://x.com/motusdao"
     },
-    "interests": ["ReFi", "SoFi", "DeSci", "Blockchain"],
+    "interests": [
+      "ReFi",
+      "SoFi",
+      "DeSci",
+      "Blockchain"
+    ],
     "description": "passionate advocate for regenerative communities and innovative Web3 solutions. With a background as a licensed psychologist, you blend expertise in mental health with decentralized technologies to drive social impact projects, including Celo Mexico, MotusDAO, ReFi Mexico."
   },
   "0xaA3600788b72863ff51C8f0dB5F10bB65fbFeAB4": {
@@ -486,7 +660,13 @@
       "website": "https://www.glodollar.org/",
       "twitter": "https://x.com/lanzdingz"
     },
-    "interests": ["ReFi", "DeFi", "Grants", "Public Goods", "Stablecoins"],
+    "interests": [
+      "ReFi",
+      "DeFi",
+      "Grants",
+      "Public Goods",
+      "Stablecoins"
+    ],
     "description": "I am a core team member and chapter lead with The GreenPill Network, as well as the Head of Growth at Glo Dollar, a stablecoin funding public goods. I serve on the Gitcoin Community Grants Council, have experience with CharmVerse's Grants Team, and am a Council member at Octant and an ambassador for Unlock Protocol. With a strong background in DAOs and community building, I bring expertise in governance and network development, and I am committed to advocating for collaborative solutions to global challenges."
   },
   "0xbd7b5d8Fdc2d21e73350741ff5C4cAC335B219a2": {
@@ -498,7 +678,11 @@
       "website": "https://celomexico.org/",
       "twitter": "https://x.com/celomexico"
     },
-    "interests": ["Blockchain", "ReFi", "SoFi"],
+    "interests": [
+      "Blockchain",
+      "ReFi",
+      "SoFi"
+    ],
     "description": "Regional Celo DAO in Mexico"
   },
   "0xe486E4F9c7efd40B999DfAD946407612c4a56C1B": {
@@ -509,7 +693,9 @@
     "links": {
       "twitter": "https://twitter.com/ezema_precious?s=21&t=8D9qM7gef6Imbd_8bublNg"
     },
-    "interests": ["DAO Governance"],
+    "interests": [
+      "DAO Governance"
+    ],
     "description": "Precious Ezema is a community builder with over 5 years experience. She has adept experience building blockchain communities. She constantly advocates for women in web3 and have worked with blockchain companies, like Celo, ethereum and Solana"
   },
   "0x2AeD14FE7bd056212cD0eD91b57a8EC5A5E33624": {
@@ -521,7 +707,12 @@
       "website": "https://linktr.ee/ricaax",
       "twitter": "https://www.twitter.com/ricaa"
     },
-    "interests": ["ReFi", "Public Goods", "Educational Programs", "Ecosystem Development"],
+    "interests": [
+      "ReFi",
+      "Public Goods",
+      "Educational Programs",
+      "Ecosystem Development"
+    ],
     "description": "Hi folks, this is Rica. I’ve been involved with Celo in one way or another for over 2 years already. I co-founded PositiveBlockchain.io and ReFi Lisboa, and I'm  the host of planta-R, the Portuguese ReFi podcast. Recently, I stepped into the Marketing Lead role for Celo EU’s 2nd season.  As a creative strategist and marketer with over a decade of experience at the intersection of business, art, tech, and impact, I focus on projects that uphold civil liberties, champion equality, nurture democratic values, and safeguard our planet’s future. I’m driven by a belief in the power of collective intelligence and decentralized communities to create meaningful change."
   },
   "0x2aa64E6d80390F5C017F0313cB908051BE2FD35e": {
@@ -533,7 +724,12 @@
       "website": "https://afolabi.info",
       "twitter": "https://twitter.com/time_is_oba"
     },
-    "interests": ["Public Goods", "Blockchains", "Augmented Reality", "Music"],
+    "interests": [
+      "Public Goods",
+      "Blockchains",
+      "Augmented Reality",
+      "Music"
+    ],
     "description": "Builder and Steward helping craft the foundations of the regen space with Greenpill & WEFA"
   },
   "0x31bCfe0836492224C71410D62d4e0532ca128B3c": {
@@ -545,7 +741,11 @@
       "website": "https://x.com/frerehugi",
       "twitter": "https://x.com/frerehugi"
     },
-    "interests": ["stablecoin usage", "trading", "CELO in East Africa"],
+    "interests": [
+      "stablecoin usage",
+      "trading",
+      "CELO in East Africa"
+    ],
     "description": "Surgeon with passion for CELO"
   },
   "0x37BAedAA536f7144E72915C683e6095177D33e78": {
@@ -575,7 +775,9 @@
       "website": "https://x.com/Slava738599",
       "twitter": "https://x.com/Slava738599"
     },
-    "interests": ["web"],
+    "interests": [
+      "web"
+    ],
     "description": "delegation"
   },
   "0x809C9f8dd8CA93A41c3adca4972Fa234C28F7714": {
@@ -586,7 +788,11 @@
     "links": {
       "twitter": "https://twitter.com/paul_glavin"
     },
-    "interests": ["Decision mechanisms", "public goods funding", "community governance"],
+    "interests": [
+      "Decision mechanisms",
+      "public goods funding",
+      "community governance"
+    ],
     "description": "building better money 🌱 Open Source Project Lead for gardens.fund"
   },
   "0x1421d52714B01298E2e9AA969e14c9317B3E1CFA": {
@@ -598,7 +804,11 @@
       "website": "https://allo.capital/",
       "twitter": "https://x.com/sejal_rekhan"
     },
-    "interests": ["Public Goods Funding", "AI", "Governance"],
+    "interests": [
+      "Public Goods Funding",
+      "AI",
+      "Governance"
+    ],
     "description": "Hi! I’m Sejal. I started my journey at Gitcoin, where I focused on community-driven grants and collaborative funding, and I’m now at Allo Capital exploring innovative funding mechanisms. I’m passionate about making Celo a hub for public goods, testing and building mechanisms that benefit everyone.  As a Celo PG Steward, I’m excited to bring my experience in PGF to support Celo’s mission."
   },
   "0x2f9B1BEDCbF3F2E060806b96d519f6261e6Fce13": {
@@ -610,7 +820,11 @@
       "website": "http://github.com/emiridbest",
       "twitter": "http://x.com/emiridbest"
     },
-    "interests": ["Defi", "Stablecoin", "DeSci"],
+    "interests": [
+      "Defi",
+      "Stablecoin",
+      "DeSci"
+    ],
     "description": "Founder @Esusu, ex Celo Camp Batch9, ex sage,  multiple hackathon winning."
   },
   "0x5670daa9De464782b7B6fc88E659F079aE7C2f94": {
@@ -648,5 +862,150 @@
       "Nature Conservation"
     ],
     "description": "David Dao is the Co-Founder of GainForest.Earth, a decentralized science non-profit dedicated to tackling the climate and biodiversity crisis with regenerative intelligence. Previously, David won the XPRIZE Rainforest Impact Prize and is the co-inventor of data valuation for machine learning. He earned his doctorate degree in computer science from ETH Zurich, and was a postdoctoral scholar in environmental science with research fellowships at MIT, UC Berkeley and Stanford."
+  },
+  "0x140D3f60AC840571a3e08e218B823094d4715564": {
+    "name": "koH",
+    "address": "0x140D3f60AC840571a3e08e218B823094d4715564",
+    "logoUri": "/logos/delegatees/0x140D3f60AC840571a3e08e218B823094d4715564.jpg",
+    "date": "2025-01-24",
+    "links": {
+      "website": "https://handprotocol.org",
+      "twitter": "https://x.com/crypto_koh"
+    },
+    "interests": [
+      "Gov",
+      "Regen",
+      "Art",
+      "AI",
+      "OSS"
+    ],
+    "description": "Hey I'm koH and my main focus is leveraging blockchain to help positive change projects. My main project is Hand Protocol which is focused on assisting regen projects or people to accomplish their missions!"
+  },
+  "0x1d8b86f4E261b6329465358f573c3B31A4a2A646": {
+    "name": "Marie-Claire Graf",
+    "address": "0x1d8b86f4E261b6329465358f573c3B31A4a2A646",
+    "logoUri": "/logos/delegatees/0x1d8b86f4E261b6329465358f573c3B31A4a2A646.jpg",
+    "date": "2025-01-31",
+    "links": {
+      "website": "https://marieclairegraf.com",
+      "twitter": "https://x.com/MarieClaireGraf"
+    },
+    "interests": [
+      "climate",
+      "diplomacy",
+      "negotiations",
+      "nature",
+      "sailing"
+    ],
+    "description": "Co-Founder of Youth Negotiators Academy for democratic governance and intergenerational leadership in environmental policy, diplomacy and decision-making processes to create a momentum for systemic change. She was initiating and is leading several associations and movements on the intersections of climate, youth and women representation, food systems transformation and education. She studied environmental and political sciences in Zurich and was a climate negotiator for Switzerland."
+  },
+  "0x20F50b8832f87104853df3FdDA47Dd464f885a49": {
+    "name": "Felix Eligbue",
+    "address": "0x20F50b8832f87104853df3FdDA47Dd464f885a49",
+    "logoUri": "/logos/delegatees/0x20F50b8832f87104853df3FdDA47Dd464f885a49.jpg",
+    "date": "2025-01-18",
+    "links": {
+      "website": "https://philix.vercel.app",
+      "twitter": "https://x.com/philixbob"
+    },
+    "interests": [
+      "Stablecoin",
+      "Defi",
+      "Impact"
+    ],
+    "description": "Software developer and Founder @pharmoprep"
+  },
+  "0x3DDC7d25c7a1dc381443e491Bbf1Caa8928A05B0": {
+    "name": "Ignas",
+    "address": "0x3DDC7d25c7a1dc381443e491Bbf1Caa8928A05B0",
+    "logoUri": "/logos/delegatees/0x3DDC7d25c7a1dc381443e491Bbf1Caa8928A05B0.png",
+    "date": "2025-01-17",
+    "links": {
+      "twitter": "https://x.com/DefiIgnas"
+    },
+    "interests": [
+      "DeFi",
+      "L1s",
+      "L2s",
+      "DAO governance"
+    ],
+    "description": "I’m Ignas, a solo researcher with the main focus on DeFi. My mission is to provide clear, in-depth insights helping my audiences stay up-to-date with the latest trends while actively supporting DAO development.  I believe in the decentralized future and it means actively participating in Arbitrum DAO in every way I can—whether it’s by serving as a delegate, joining working groups, discussing any proposals or seizing new opportunities that come up. I’ll also be sharing key DAO decisions on X and my blog."
+  },
+  "0x5523058cdFfe5F3c1EaDADD5015E55C6E00fb439": {
+    "name": "Grassroots Economics",
+    "address": "0x5523058cdFfe5F3c1EaDADD5015E55C6E00fb439",
+    "logoUri": "/logos/delegatees/0x5523058cdFfe5F3c1EaDADD5015E55C6E00fb439.png",
+    "date": "2025-01-20",
+    "links": {
+      "website": "https://grassrootseconomics.org",
+      "twitter": "https://x.com/grassecon"
+    },
+    "interests": [
+      "Open Source",
+      "Governance",
+      "ReFi",
+      "Community",
+      "Engineering"
+    ],
+    "description": "Grassroots Economics is a non-profit foundation that seeks to support communities to take charge of their own livelihoods and economic future. We focus on community development through commons and are dedicated to helping communities realize and share their abundance through Economic Commons with Instruments like Community Asset Vouchers and Commitment Pooling that can act as a medium of exchange and commons. While core beneficiaries of our programs include businesses and people living in informal settlements as well as rural areas, the documentation and tools have been broadly applied worldwide.  It is tremendously important to us that people take, use, build on and share what we've found to be useful. Join us in demonstrating, disseminating, designing & curating the best practices to empower communities to create and manage their own financial instruments. All our software, websites, materials are CopyLeft under AGPL 3.0 for software and Creative Commons Share-Alike With Attribution. Please copy, modify and"
+  },
+  "0x6820442229778647b77cA1bb1746d1966dEbe3Ea": {
+    "name": "Vow",
+    "address": "0x6820442229778647b77cA1bb1746d1966dEbe3Ea",
+    "logoUri": "/logos/delegatees/0x6820442229778647b77cA1bb1746d1966dEbe3Ea.jpg",
+    "date": "2025-01-15",
+    "links": {
+      "website": "https://x.com/VowIMTX",
+      "twitter": "https://x.com/VowIMTX"
+    },
+    "interests": [
+      "Blockchain",
+      "Sustainable"
+    ],
+    "description": "Advisor at KohCelo"
+  },
+  "0xCDaba8e196D9BF1DabdF6b5D3Bc3BFD175FF81c8": {
+    "name": "UMN Blockchain",
+    "address": "0xCDaba8e196D9BF1DabdF6b5D3Bc3BFD175FF81c8",
+    "logoUri": "/logos/delegatees/0xCDaba8e196D9BF1DabdF6b5D3Bc3BFD175FF81c8.jpg",
+    "date": "2025-01-22",
+    "links": {
+      "website": "https://www.umnbc.org/",
+      "twitter": "https://x.com/umnblockchain"
+    },
+    "interests": [
+      "Blockchain"
+    ],
+    "description": "Club at University of Minnesota dedicated to Blockchain"
+  },
+  "0xba3982536F79090D4d68cD14e1B7d15fF1014030": {
+    "name": "Anthony Annaelechukwu Nduka",
+    "address": "0xba3982536F79090D4d68cD14e1B7d15fF1014030",
+    "logoUri": "/logos/delegatees/0xba3982536F79090D4d68cD14e1B7d15fF1014030.jpeg",
+    "date": "2025-01-29",
+    "links": {
+      "twitter": "https://x.com/ndukaanthonya"
+    },
+    "interests": [
+      "Community",
+      "NFTs",
+      "DAO",
+      "Stablecoins"
+    ],
+    "description": "Community Developer"
+  },
+  "0xcFB5a8A167c1E437e34d82C25Cc0Ef24d4f27d4b": {
+    "name": "CalBlockchain",
+    "address": "0xcFB5a8A167c1E437e34d82C25Cc0Ef24d4f27d4b",
+    "logoUri": "/logos/delegatees/0xcFB5a8A167c1E437e34d82C25Cc0Ef24d4f27d4b.jpg",
+    "date": "2025-02-03",
+    "links": {
+      "website": "https://blockchain.studentorg.berkeley.edu/",
+      "twitter": "https://x.com/CalBlockchain"
+    },
+    "interests": [
+      "Blockchain"
+    ],
+    "description": "Student Organization at Berkeley focused on blockchain innovation, education, consulting, and research. Founded in 2014."
   }
 }

--- a/src/config/proposals.json
+++ b/src/config/proposals.json
@@ -2359,7 +2359,7 @@
     "cgpUrl": "https://github.com/celo-org/governance/blob/main/CGPs/cgp-0155.md",
     "cgpUrlRaw": "https://raw.githubusercontent.com/celo-org/governance/main/CGPs/cgp-0155.md",
     "title": "Add CeloToken and LockedCelo to the registry",
-    "author": "Sebastien Benoit (@soloseng), Martín Volpe (@martinvol)",
+    "author": "@soloseng, Martín Volpe (@martinvol)",
     "stage": 0,
     "timestamp": 1731974400000
   },

--- a/src/features/governance/hooks/useGovernanceProposals.ts
+++ b/src/features/governance/hooks/useGovernanceProposals.ts
@@ -316,7 +316,7 @@ export function pessimisticallyHandleMismatchedIDs(
   proposal: Proposal,
 ): MergedProposalData {
   if (executedIds.includes(metadata.id!)) {
-    // the proposal is WRONG use the trust the metadata
+    // the proposal is WRONG, trust the metadata
     // do NOT use votes from the proposal they are wrong
     return {
       stage: ProposalStage.Executed,


### PR DESCRIPTION
Initiated by situation when a proposal failed, its replacement suceeded, but we never ran the scripts while it was active on chain. now the github metadata points to the correct proposals and the on chain proposal id is expired. 

note the most crucial fix is that even though we were correctly using executed-ids to determine that we were passing in the wrong old votes. 


moving around to and new tests are mostly about making this easier to fix if there is an issue in future with an active on-chain  replacement proposal.