### PR TITLE
fix the in progress voting proposal.

### DIFF
--- a/src/features/governance/hooks/useGovernanceProposals.test.ts
+++ b/src/features/governance/hooks/useGovernanceProposals.test.ts
@@ -179,6 +179,27 @@ describe('pessimisticallyHandleMismatchedIDs', () => {
     votes: undefined,
   } as const;
 
+  const proposalMap = new Map<number, Proposal>();
+
+  proposalMap.set(212, {
+    id: 212,
+    stage: 3,
+    timestamp: 1740839940000,
+    expiryTimestamp: 1741444740000,
+    proposer: '0xFEF5A1A2b3754A2F53161EaaAcb3EB889F004d4a',
+    deposit: 10000000000000000000000n,
+    numTransactions: 2n,
+    networkWeight: 0n,
+    isApproved: false,
+    url: 'https://github.com/celo-org/governance/blob/main/CGPs/cgp-0165.md',
+    upvotes: 0n,
+    votes: {
+      yes: 0n,
+      no: 0n,
+      abstain: 0n,
+    },
+  });
+
   // values not used in test
   const proposalCommon = {
     timestamp: Date.now(),
@@ -212,7 +233,9 @@ describe('pessimisticallyHandleMismatchedIDs', () => {
         cgp: 101,
         ...metdataCommon,
       };
-      expect(pessimisticallyHandleMismatchedIDs(executedIDS, metadata, proposal)).toEqual({
+      expect(
+        pessimisticallyHandleMismatchedIDs(executedIDS, metadata, proposal, proposalMap),
+      ).toEqual({
         id: executedID,
         metadata: { ...metadata, id: executedID },
         stage: ProposalStage.Executed,
@@ -237,7 +260,9 @@ describe('pessimisticallyHandleMismatchedIDs', () => {
         cgp: 101,
         ...metdataCommon,
       };
-      expect(pessimisticallyHandleMismatchedIDs(executedIDS, metadata, proposal)).toEqual({
+      expect(
+        pessimisticallyHandleMismatchedIDs(executedIDS, metadata, proposal, proposalMap),
+      ).toEqual({
         id: executedID,
         stage: ProposalStage.Executed,
         metadata: metadata,
@@ -262,10 +287,54 @@ describe('pessimisticallyHandleMismatchedIDs', () => {
         cgp: 101,
         ...metdataCommon,
       };
-      expect(pessimisticallyHandleMismatchedIDs(executedIDS, metadata, proposal)).toEqual({
+      expect(
+        pessimisticallyHandleMismatchedIDs(executedIDS, metadata, proposal, proposalMap),
+      ).toEqual({
         id: 62,
         metadata: { ...metadata, votes: undefined },
         stage: metadata.stage,
+        proposal,
+      });
+    });
+  });
+  describe('when neither id has been executed', () => {
+    const proposal: Proposal = {
+      id: 212,
+      stage: 3,
+      timestamp: 1740839940000,
+      expiryTimestamp: 1741444740000,
+      proposer: '0xFEF5A1A2b3754A2F53161EaaAcb3EB889F004d4a',
+      deposit: 10000000000000000000000n,
+      numTransactions: 2n,
+      networkWeight: 0n,
+      isApproved: false,
+      url: 'https://github.com/celo-org/governance/blob/main/CGPs/cgp-0165.md',
+      upvotes: 0n,
+      votes: {
+        yes: 0n,
+        no: 0n,
+        abstain: 0n,
+      },
+    };
+    const metadata: ProposalMetadata = {
+      cgp: 165,
+      cgpUrl: 'https://github.com/celo-org/governance/blob/main/CGPs/cgp-0165.md',
+      cgpUrlRaw: 'https://raw.githubusercontent.com/celo-org/governance/main/CGPs/cgp-0165.md',
+      title: 'Celo Communities Guild Proposal 2025 H1 Budget',
+      author:
+        'Celo communities Guild: 0xj4an-work (@0xj4an-work), Goldo (@0xGoldo), Anthony (@0xKnight)',
+      stage: 1,
+      id: 207,
+      url: 'https://forum.celo.org/t/celo-communities-guild-proposal-2025-h1-budget',
+      timestamp: 1739491200000,
+    };
+    it('returns the higher one (on the assumption that new is probably correct', () => {
+      expect(
+        pessimisticallyHandleMismatchedIDs(executedIDS, metadata, proposal, proposalMap),
+      ).toEqual({
+        id: 212,
+        metadata: { ...metadata, id: 212, stage: 3 },
+        stage: 3,
         proposal,
       });
     });

--- a/src/features/governance/hooks/useGovernanceProposals.ts
+++ b/src/features/governance/hooks/useGovernanceProposals.ts
@@ -220,6 +220,7 @@ export function mergeProposalsWithMetadata(
   const sortedMetadata = [...metadata].sort((a, b) => b.cgp - a.cgp);
   const merged: Array<MergedProposalData> = [];
   const proposalMap = new Map(sortedProposals.map((p) => [p.id, p]));
+
   for (const proposal of sortedProposals) {
     // First, try to match using the proposal ID
     let metadataIndex = sortedMetadata.findIndex((m) => m.id === proposal.id);
@@ -238,16 +239,9 @@ export function mergeProposalsWithMetadata(
       const metadata = sortedMetadata.splice(metadataIndex, 1)[0];
 
       if (metadata.id && metadata.id !== proposal.id) {
-        // case when both proposals are still available on chain (ie not expired yet)
-        const proposalFromMetaData = proposalMap.get(metadata.id);
-        // get it next time we around. just skip it for now
-        if (proposalFromMetaData) {
-          // add it back  it can be found when we are on the correct proposal
-          sortedMetadata.push(metadata);
-          continue;
-        } else {
-          merged.push(pessimisticallyHandleMismatchedIDs(executedIds, metadata, proposal));
-        }
+        merged.push(
+          pessimisticallyHandleMismatchedIDs(executedIds, metadata, proposal, proposalMap),
+        );
       } else {
         // happy normal case
         // Add it to the merged array, giving priority to on-chain stage
@@ -314,6 +308,7 @@ export function pessimisticallyHandleMismatchedIDs(
   executedIds: number[],
   metadata: ProposalMetadata,
   proposal: Proposal,
+  proposalMap: Map<number, Proposal>,
 ): MergedProposalData {
   if (executedIds.includes(metadata.id!)) {
     // the proposal is WRONG, trust the metadata
@@ -337,12 +332,19 @@ export function pessimisticallyHandleMismatchedIDs(
   ) {
     return { stage: metadata.stage, id: metadata.id, proposal, metadata };
   } else {
+    const probableID = Math.max(metadata.id!, proposal.id);
+
+    const probableStage = probableID === metadata.id ? metadata.stage : proposal.stage;
+
+    const metaData = { ...metadata, id: probableID, stage: probableStage };
+
     // what would cause this
     // none like this currently show. but if they do they should be handled
     return {
-      stage: metadata.stage,
-      id: metadata.id,
-      metadata: { ...metadata },
+      stage: probableStage,
+      id: probableID,
+      metadata: metaData,
+      proposal: proposalMap.get(probableID),
     };
   }
 }

--- a/src/features/governance/hooks/useGovernanceProposals.ts
+++ b/src/features/governance/hooks/useGovernanceProposals.ts
@@ -319,6 +319,7 @@ export function pessimisticallyHandleMismatchedIDs(
       stage: ProposalStage.Executed,
       id: metadata.id,
       metadata: { ...metadata, votes: undefined },
+      proposal: proposalMap.get(metadata.id!),
     };
   } else if (executedIds.includes(proposal.id)) {
     // the proposal was exectuted so it is correct

--- a/src/features/governance/hooks/useGovernanceProposals.ts
+++ b/src/features/governance/hooks/useGovernanceProposals.ts
@@ -221,6 +221,8 @@ export function mergeProposalsWithMetadata(
   const merged: Array<MergedProposalData> = [];
   const proposalMap = new Map(sortedProposals.map((p) => [p.id, p]));
 
+  // One day deduping proposals first will might be a better approach
+
   for (const proposal of sortedProposals) {
     // First, try to match using the proposal ID
     let metadataIndex = sortedMetadata.findIndex((m) => m.id === proposal.id);


### PR DESCRIPTION
use the higher of the values as the heuristic

previous idea of merging stuff back into the array didnt help and feels bad.

also why is metadata pointing to the wrong proposal anyway? caching?

Probably better would be to do the deduping of proposals BEFORE merging in metadata.



fixe #175 
