### PR TITLE
Show Previous onchain votes for same cgp on governance proposal page

### DIFF
--- a/src/config/proposals.json
+++ b/src/config/proposals.json
@@ -2359,8 +2359,10 @@
     "cgpUrl": "https://github.com/celo-org/governance/blob/main/CGPs/cgp-0155.md",
     "cgpUrlRaw": "https://raw.githubusercontent.com/celo-org/governance/main/CGPs/cgp-0155.md",
     "title": "Add CeloToken and LockedCelo to the registry",
-    "author": "@soloseng, Martín Volpe (@martinvol)",
-    "stage": 0,
+    "author": "Martín Volpe (@martinvol), @soloseng",
+    "stage": 1,
+    "id": 210,
+    "url": "https://forum.celo.org/t/add-celotoken-and-lockedcelo-to-the-registry/10315",
     "timestamp": 1731974400000
   },
   {
@@ -2505,7 +2507,7 @@
     "title": "Celo Communities Guild Proposal 2025 H1 Budget",
     "author": "Celo communities Guild: 0xj4an-work (@0xj4an-work), Goldo (@0xGoldo), Anthony (@0xKnight)",
     "stage": 1,
-    "id": 207,
+    "id": 212,
     "url": "https://forum.celo.org/t/celo-communities-guild-proposal-2025-h1-budget",
     "timestamp": 1739491200000
   },
@@ -2528,5 +2530,25 @@
     "stage": 0,
     "url": "https://forum.celo.org/t/set-parameters-for-l2-transition/10365",
     "timestamp": 1739577600000
+  },
+  {
+    "cgp": 168,
+    "cgpUrl": "https://github.com/celo-org/governance/blob/main/CGPs/cgp-0168.md",
+    "cgpUrlRaw": "https://raw.githubusercontent.com/celo-org/governance/main/CGPs/cgp-0168.md",
+    "title": "Budget Request: Prezenti Grant funding: Season 0",
+    "author": "Wade @0xzoz , Maya @Maya-R-B , Aaron @aaronmboyd",
+    "stage": 1,
+    "id": 211,
+    "url": "https://forum.celo.org/t/budget-request-prezenti-grant-funding-season-0",
+    "timestamp": 1740614400000
+  },
+  {
+    "cgp": 169,
+    "cgpUrl": "https://github.com/celo-org/governance/blob/main/CGPs/cgp-0169.md",
+    "cgpUrlRaw": "https://raw.githubusercontent.com/celo-org/governance/main/CGPs/cgp-0169.md",
+    "title": "Set The Great Celo Halvening Parameters",
+    "author": "cLabs Team",
+    "stage": 0,
+    "timestamp": 1708992000000
   }
 ]

--- a/src/features/governance/components/Proposal.tsx
+++ b/src/features/governance/components/Proposal.tsx
@@ -13,6 +13,7 @@ import {
   ProposalVoteButtons,
 } from 'src/features/governance/components/ProposalVoteButtons';
 import {
+  PastProposalVoteChart,
   ProposalQuorumChart,
   ProposalVoteChart,
 } from 'src/features/governance/components/ProposalVoteChart';
@@ -102,7 +103,7 @@ function ProposalContent({ propData }: { propData: MergedProposalData }) {
 }
 
 function ProposalChainData({ propData }: { propData: MergedProposalData }) {
-  const { id, stage, proposal, metadata } = propData;
+  const { id, stage, proposal, metadata, history } = propData;
   const expiryTimestamp = proposal?.expiryTimestamp;
 
   if (stage === ProposalStage.None) return null;
@@ -133,6 +134,14 @@ function ProposalChainData({ propData }: { propData: MergedProposalData }) {
       {stage >= ProposalStage.Referendum && (
         <div className="hidden overflow-auto border-taupe-300 p-3 lg:block lg:border">
           <ProposalVotersTable propData={propData} />
+        </div>
+      )}
+      {history && history.length > 0 && (
+        <div className="space-y-4 border-taupe-300 p-3 lg:border">
+          <h2 className="font-serif text-2xl">Past Onchain Results</h2>
+          {history.map((id) => (
+            <PastProposalVoteChart key={id} title={`As #${id}`} id={id} />
+          ))}
         </div>
       )}
     </div>

--- a/src/features/governance/components/ProposalVoteChart.tsx
+++ b/src/features/governance/components/ProposalVoteChart.tsx
@@ -7,19 +7,50 @@ import {
   useIsProposalPassing,
   useProposalQuorum,
 } from 'src/features/governance/hooks/useProposalQuorum';
-import { useProposalVoteTotals } from 'src/features/governance/hooks/useProposalVoteTotals';
-import { EmptyVoteAmounts, VoteToColor, VoteType, VoteTypes } from 'src/features/governance/types';
+import {
+  useHistoricalProposalVoteTotals,
+  useProposalVoteTotals,
+} from 'src/features/governance/hooks/useProposalVoteTotals';
+import {
+  EmptyVoteAmounts,
+  VoteAmounts,
+  VoteToColor,
+  VoteType,
+  VoteTypes,
+} from 'src/features/governance/types';
 import { Color } from 'src/styles/Color';
 import { fromWei } from 'src/utils/amount';
 import { bigIntSum, percent } from 'src/utils/math';
 import { objKeys } from 'src/utils/objects';
 import { toTitleCase } from 'src/utils/strings';
 
+export function PastProposalVoteChart({ id, title = 'Result' }: { id: number; title?: string }) {
+  const { isLoading, votes } = useHistoricalProposalVoteTotals(id);
+
+  const totalVotes = bigIntSum(Object.values(votes || {}));
+
+  return <ViewVotes votes={votes} totalVotes={totalVotes} title={title} isLoading={isLoading} />;
+}
+
 export function ProposalVoteChart({ propData }: { propData: MergedProposalData }) {
   const { isLoading, votes } = useProposalVoteTotals(propData);
 
   const totalVotes = bigIntSum(Object.values(votes || {}));
 
+  return <ViewVotes votes={votes} totalVotes={totalVotes} isLoading={isLoading} />;
+}
+
+function ViewVotes({
+  votes,
+  title = 'Result',
+  totalVotes,
+  isLoading,
+}: {
+  totalVotes: bigint;
+  votes: VoteAmounts | undefined;
+  title?: string;
+  isLoading?: boolean;
+}) {
   const voteBarChartData = useMemo(
     () =>
       objKeys(EmptyVoteAmounts).reduce(
@@ -47,7 +78,7 @@ export function ProposalVoteChart({ propData }: { propData: MergedProposalData }
 
   return (
     <div className="space-y-2">
-      <h2 className="font-serif text-2xl">Result</h2>
+      <h2 className="font-serif text-2xl">{title}</h2>
       <div className="space-y-1.5">
         {Object.values(VoteTypes).map((v) => (
           <div key={v} className="relative text-xs">

--- a/src/features/governance/hooks/useProposalVoteTotals.ts
+++ b/src/features/governance/hooks/useProposalVoteTotals.ts
@@ -5,6 +5,28 @@ import { fetchProposalVoters } from 'src/features/governance/hooks/useProposalVo
 import { ProposalStage } from 'src/features/governance/types';
 import { logger } from 'src/utils/logger';
 
+export function useHistoricalProposalVoteTotals(id: number) {
+  const { isLoading, isError, error, data } = useQuery({
+    queryKey: ['useHistoricalProposalVoteTotals', id],
+    queryFn: async () => {
+      if (!id) return null;
+
+      logger.debug(`Fetching historical proposals votes for ${id}`);
+      return fetchProposalVoters(id);
+    },
+    gcTime: Infinity,
+    staleTime: 60 * 60 * 1000 * 4, // 4 hour
+  });
+
+  useToastError(error, 'Error fetching historical proposals vote totals');
+
+  return {
+    isLoading,
+    isError,
+    votes: data?.totals,
+  };
+}
+
 export function useProposalVoteTotals(propData?: MergedProposalData) {
   const {
     isLoading,


### PR DESCRIPTION
show votes for past onchain ids related to same cp id. this will only work if the old id is still in the cgp or if the proposal id still exists on chain as there is no store of these old ids yet


<img width="410" alt="Screenshot 2025-03-08 at 16 20 18" src="https://github.com/user-attachments/assets/f40b8ebd-18a6-4e75-b632-159f19e49adf" />
