### PR TITLE
fixes issues with proposal  line items and code displaying as cut off

### DIFF
--- a/src/features/governance/components/styles.module.css
+++ b/src/features/governance/components/styles.module.css
@@ -49,6 +49,7 @@
 .proposal ol,
 .proposal ul {
   padding-left: 1rem;
+  margin-inline-start: 1rem;
 }
 
 .proposal ul {
@@ -60,14 +61,14 @@
 }
 
 .proposal li {
-  padding-left: 1rem;
+  padding-left: 0.6rem;
   margin-top: 0.6rem;
 }
 
 .proposal pre {
   padding: 0.5rem;
   background-color: rgba(0, 0, 0, 0.04);
-  overflow-x: hidden;
+  overflow-x: scroll;
 }
 
 .proposal img {


### PR DESCRIPTION
* Bullet points were cut off and not showing full number
* add scrolling on pre so all can be viewed

## now
<img width="593" alt="Screenshot 2025-03-13 at 12 36 09" src="https://github.com/user-attachments/assets/6a2189fe-a62d-412f-85a0-e100aa59494a" />

## before
<img width="440" alt="Screenshot 2025-03-13 at 12 36 26" src="https://github.com/user-attachments/assets/9aa4e8b9-c94b-476f-9945-10ca6980190a" />

## code scrolling
https://github.com/user-attachments/assets/da37f167-8258-4366-8983-eac08c020d69



## fixes 
https://github.com/celo-org/celo-mondo/issues/191