### PR TITLE
Fix delegation amounts in delegators table

### DIFF
--- a/src/features/delegation/hooks/useDelegators.ts
+++ b/src/features/delegation/hooks/useDelegators.ts
@@ -6,7 +6,7 @@ import { Addresses } from 'src/config/contracts';
 import { queryCeloscanLogs } from 'src/features/explorers/celoscan';
 import { TransactionLog } from 'src/features/explorers/types';
 import { logger } from 'src/utils/logger';
-import { Address, decodeEventLog, encodeEventTopics, PublicClient } from 'viem';
+import { Address, PublicClient, decodeEventLog, encodeEventTopics } from 'viem';
 import { usePublicClient } from 'wagmi';
 
 /**

--- a/src/features/delegation/hooks/useDelegators.ts
+++ b/src/features/delegation/hooks/useDelegators.ts
@@ -16,7 +16,7 @@ export function useDelegators(delegateAddress?: Address) {
   const client = usePublicClient();
 
   const { isLoading, isError, error, data, refetch } = useQuery({
-    queryKey: ['useDelegators', delegateAddress],
+    queryKey: ['useDelegators', delegateAddress, client],
     queryFn: () => {
       if (!delegateAddress || !client) {
         return null;


### PR DESCRIPTION
This PR fixes incorrect/not all showing delegations in the delegators table for a delegatee.

Fixes #164 

**How to QA**

Compare `0x31cd90C2788f3e390d2Bb72871f5aD3F1a4B22a1` delegators (`/delegate/0x31cd90C2788f3e390d2Bb72871f5aD3F1a4B22a1` on preview)

vs https://mondo.celo.org/delegate/0x31cd90C2788f3e390d2Bb72871f5aD3F1a4B22a1

and notice the difference in delegation amounts, now they (taking into account possible rounding differences) should add up to the value displayed under `Delegated`

Same for `0xFEF5A1A2b3754A2F53161EaaAcb3EB889F004d4a`, but this time notice that the missing delegator is displayed as well (as reported in [the original issue](https://github.com/celo-org/celo-mondo/issues/164)).

