### PR TITLE
Safe delegate registration hax

### DIFF
--- a/public/docs/delegating-as-safe.md
+++ b/public/docs/delegating-as-safe.md
@@ -1,0 +1,91 @@
+# Delegating as a SAFE
+
+Registering to Delegate from a SAFE is not working due to a few technical challenges. 
+
+This instructions show how to create a Pull Request to register your SAFE as a Delegate anyway.
+
+## Create a Fork of Celo MONDO
+
+Go to https://github.com/celo-org/celo-mondo/fork
+
+
+## Clone The Repo
+
+`git clone <URL FORK URL>`
+
+## Crate a branch
+
+`git branch delegatee/YOUR_ACCOUNT_ADDRESSS_OR_NAME`
+
+`git checkout NAME_OF_YOUR_BRANCH`
+
+## Add the required files 
+
+1. in `public/logos/` an image of your logo (can be png or jpg) 
+
+full path like 
+
+```
+public/logos/delegatees/0xe77839713Ba66eCd041747CC1F43357CC9e665b2.png
+```
+
+*SHOULD BE SQUARE!*
+
+
+2. in `src/config/delegatees/` a JSON file named `YOUR_ADDRESS.json` FULL PATH would be like.
+
+```
+src/config/delegatees/0xe77839713Ba66eCd041747CC1F43357CC9e665b2.json
+```
+
+with contents like 
+
+```json
+{
+  "name": "YOUR ORG NAME",
+  "address": "0xe77839713Ba66eCd041747CC1F43357CC9e665b2",
+  "logoUri": "/logos/delegatees/0xe77839713Ba66eCd041747CC1F43357CC9e665b2.png",
+  "date": "2025-03-12",
+  "links": {
+    "website": "https://your-website.com",
+    "twitter": "https://x.com/your-social",
+    "github": "https://github.com/your-username",
+  },
+  "interests": [
+    "Development"
+  ],
+  "description": "This is an example of a short description of why people would delegate to you"
+}
+```
+
+### REQUIREMENTS
+
+* the logURI MUST match the image path you provided (leave off the public part)
+* interests must ba an array of strings
+* date must be near todays and in YYYY-MM-DD format
+* all links (are optional) however any you include MUST start with https:// 
+
+## Commits the files and push
+
+`git add .` // note this adds everything in workdirectory
+`git commit -m "Adding Delegate"
+
+`git push origin`
+
+## Open a PR
+
+Now you should be able to navigate to github on your fork and if you just pushed it should have a link directly there to open a PR.
+
+### Title your PR
+
+PR should Be Tiltled "Adding Delegatee {YOUR GROUP NAME}"
+
+### Proving yourself
+
+* In the PR description you MUST provide a link to a social media or webpage that is clearly owned by the group you are representing AND which itself mentions the address your are registering under. 
+
+* If possible the person Opening the PR should be a member on github for the group you are registering. (I.E. dont try and register as Blockchain CalTech but clearly only belong to Blockchain MIT)
+
+## Care for your PR
+
+Please Check back reguarly on the status of your PR, once we enable checks to run if you see lint errors please fix them.

--- a/src/features/delegation/DelegateRegistrationForm.tsx
+++ b/src/features/delegation/DelegateRegistrationForm.tsx
@@ -6,6 +6,7 @@ import { SolidButtonWithSpinner } from 'src/components/buttons/SolidButtonWithSp
 import { ImageOrIdenticon } from 'src/components/icons/Identicon';
 import { TextField } from 'src/components/input/TextField';
 import { Modal, useModal } from 'src/components/menus/Modal';
+import { delegateeRegistrationRequestToMetadata } from 'src/features/delegation/delegateeMetadata';
 import { useDelegatedPercent } from 'src/features/delegation/hooks/useDelegatedPercent';
 import { useIsSAFEWallet, useSignedData } from 'src/features/delegation/hooks/useSIgnedData';
 import {
@@ -93,19 +94,21 @@ export function DelegateRegistrationForm({
           setIsSubmitting(true);
           setIsSigning(true);
 
+          const registrationValues = {
+            ...values,
+            address: address!,
+            image: imageFile,
+          };
+
           if (isSAFE) {
-            openModal(values);
+            openModal(registrationValues);
             setIsSigning(false);
             setIsSubmitting(false);
             return;
           }
 
           try {
-            signature = await signForm({
-              ...values,
-              address: address!,
-              image: imageFile,
-            });
+            signature = await signForm(registrationValues);
           } catch (err) {
             setIsSubmitting(false);
 
@@ -320,15 +323,24 @@ function SafeModal({
         </p>
         <p className="mb-4">
           Please Follow{' '}
-          <a className="link" href="/docs/delegating-as-safe.md">
+          <a className="link" href={'/docs/delegating-as-safe.md'}>
             These Instructions to register
           </a>
         </p>
         <hr />
-        <h3 className="mb-4 mt-4 text-sm">
-          Your Data (note that this format differs slightly from the requirements)
-        </h3>
-        <pre>{JSON.stringify(values, null, 2)}</pre>
+        <h3 className="mb-4 mt-4 text-sm">Use the following JSON in your PR.</h3>
+        <pre className="bg-white p-2">
+          {isModalOpen && Object.prototype.hasOwnProperty.call(values, 'image')
+            ? JSON.stringify(
+                delegateeRegistrationRequestToMetadata(
+                  values as RegisterDelegateFormValues,
+                  new Date(),
+                ),
+                null,
+                2,
+              )
+            : null}
+        </pre>
         <br />
       </div>
     </Modal>

--- a/src/features/delegation/DelegateRegistrationForm.tsx
+++ b/src/features/delegation/DelegateRegistrationForm.tsx
@@ -5,10 +5,13 @@ import { toast } from 'react-toastify';
 import { SolidButtonWithSpinner } from 'src/components/buttons/SolidButtonWithSpinner';
 import { ImageOrIdenticon } from 'src/components/icons/Identicon';
 import { TextField } from 'src/components/input/TextField';
-import { Modal, useModal } from 'src/components/menus/Modal';
-import { delegateeRegistrationRequestToMetadata } from 'src/features/delegation/delegateeMetadata';
+import {
+  DelegateSafeWalletModal,
+  useIsSAFEWallet,
+  useSAFEModal,
+} from 'src/features/delegation/DelegateSafeWalletModal';
 import { useDelegatedPercent } from 'src/features/delegation/hooks/useDelegatedPercent';
-import { useIsSAFEWallet, useSignedData } from 'src/features/delegation/hooks/useSIgnedData';
+import { useSignedData } from 'src/features/delegation/hooks/useSignedData';
 import {
   RegisterDelegateFormValues,
   RegisterDelegateResponse,
@@ -40,7 +43,7 @@ export function DelegateRegistrationForm({
   const [pullRequestUrl, setPullRequestUrl] = useState<string | null>(null);
   const signForm = useSignedData();
   const isSAFE = useIsSAFEWallet();
-  const { isModalOpen, openModal, closeModal, values: formDataValues } = useSafeModal();
+  const { isModalOpen, openModal, closeModal, values: formDataValues } = useSAFEModal();
   const { delegatedPercent } = useDelegatedPercent(address);
 
   const validate = async (values: RegisterDelegateFormValues, image: File | null) => {
@@ -299,67 +302,11 @@ export function DelegateRegistrationForm({
           </Form>
         )}
       </Formik>
-      <SafeModal isModalOpen={isModalOpen} close={closeModal} values={formDataValues} />
+      <DelegateSafeWalletModal
+        isModalOpen={isModalOpen}
+        close={closeModal}
+        values={formDataValues}
+      />
     </>
   );
-}
-
-function SafeModal({
-  isModalOpen,
-  close,
-  values,
-}: {
-  values: RegisterDelegateFormValues | {};
-  isModalOpen: boolean;
-  close: () => void;
-}) {
-  return (
-    <Modal isOpen={isModalOpen} close={close}>
-      <div className="max-w-36[rem] flex min-h-[24rem] min-w-[18rem] flex-col border border-taupe-300 bg-taupe-100 p-2.5 pt-8">
-        <h2 className="font-serif text-xl">Registering from SAFE Instructions</h2>
-        <p className="my-4">
-          The Connected Address Appears to be a SAFE wallet. There are bugs related to registering
-          (but not acting as) a delegatee.
-        </p>
-        <p className="mb-4">
-          Please Follow{' '}
-          <a className="link" href={'/docs/delegating-as-safe.md'}>
-            These Instructions to register
-          </a>
-        </p>
-        <hr />
-        <h3 className="mb-4 mt-4 text-sm">Use the following JSON in your PR.</h3>
-        <pre className="bg-white p-2">
-          {isModalOpen && Object.prototype.hasOwnProperty.call(values, 'image')
-            ? JSON.stringify(
-                delegateeRegistrationRequestToMetadata(
-                  values as RegisterDelegateFormValues,
-                  new Date(),
-                ),
-                null,
-                2,
-              )
-            : null}
-        </pre>
-        <br />
-      </div>
-    </Modal>
-  );
-}
-
-function useSafeModal() {
-  const { isModalOpen, openModal, closeModal } = useModal();
-  const [values, setValues] = useState<RegisterDelegateFormValues | {}>({});
-
-  function openModalWithValues(_values: RegisterDelegateFormValues) {
-    setValues(_values);
-    openModal();
-  }
-
-  return {
-    isModalOpen,
-    openModal: openModalWithValues,
-    closeModal,
-    values,
-  };
 }

--- a/src/features/delegation/DelegateRegistrationForm.tsx
+++ b/src/features/delegation/DelegateRegistrationForm.tsx
@@ -5,8 +5,9 @@ import { toast } from 'react-toastify';
 import { SolidButtonWithSpinner } from 'src/components/buttons/SolidButtonWithSpinner';
 import { ImageOrIdenticon } from 'src/components/icons/Identicon';
 import { TextField } from 'src/components/input/TextField';
+import { Modal, useModal } from 'src/components/menus/Modal';
 import { useDelegatedPercent } from 'src/features/delegation/hooks/useDelegatedPercent';
-import { useSignedData } from 'src/features/delegation/hooks/useSIgnedData';
+import { useIsSAFEWallet, useSignedData } from 'src/features/delegation/hooks/useSIgnedData';
 import {
   RegisterDelegateFormValues,
   RegisterDelegateResponse,
@@ -37,6 +38,8 @@ export function DelegateRegistrationForm({
   const [isSigning, setIsSigning] = useState(false);
   const [pullRequestUrl, setPullRequestUrl] = useState<string | null>(null);
   const signForm = useSignedData();
+  const isSAFE = useIsSAFEWallet();
+  const { isModalOpen, openModal, closeModal, values: formDataValues } = useSafeModal();
   const { delegatedPercent } = useDelegatedPercent(address);
 
   const validate = async (values: RegisterDelegateFormValues, image: File | null) => {
@@ -78,210 +81,273 @@ export function DelegateRegistrationForm({
   }
 
   return (
-    <Formik<RegisterDelegateFormValues>
-      initialValues={{
-        ...defaultFormValues,
-        ...initialValues,
-      }}
-      onSubmit={async (values) => {
-        let signature: HexString;
+    <>
+      <Formik<RegisterDelegateFormValues>
+        initialValues={{
+          ...defaultFormValues,
+          ...initialValues,
+        }}
+        onSubmit={async (values) => {
+          let signature: HexString;
 
-        setIsSubmitting(true);
-        setIsSigning(true);
+          setIsSubmitting(true);
+          setIsSigning(true);
 
-        try {
-          signature = await signForm({
-            ...values,
-            address: address!,
-            image: imageFile,
-          });
-        } catch (err) {
-          setIsSubmitting(false);
-
-          toast.error('Error while signing message');
-          logger.error(err);
-
-          return;
-        }
-
-        setIsSigning(false);
-
-        const request = new FormData();
-
-        request.append('image', imageFile as Blob);
-        request.append('name', values.name);
-        request.append('interests', values.interests);
-        request.append('description', values.description);
-        request.append('signature', signature);
-
-        if (values.twitterUrl) {
-          request.append('twitterUrl', values.twitterUrl);
-        }
-
-        if (values.websiteUrl) {
-          request.append('websiteUrl', values.websiteUrl);
-        }
-
-        request.append('verificationUrl', values.verificationUrl);
-        request.append('address', address!);
-
-        try {
-          const httpResponse = await fetch('/delegate/api/register', {
-            method: 'POST',
-            body: request,
-          });
-
-          if (httpResponse.ok) {
-            const response = (await httpResponse.json()) as RegisterDelegateResponse;
-
-            if (response.status === RegisterDelegateResponseStatus.Success) {
-              setPullRequestUrl(response.pullRequestUrl);
-            } else {
-              toast.error(response.message);
-            }
-          } else {
-            toast.error('Error while registering delegatee');
+          if (isSAFE) {
+            openModal(values);
+            setIsSigning(false);
+            setIsSubmitting(false);
+            return;
           }
-        } catch (err) {
-          toast.error(`Error while registering delegatee: ${(err as Error).message}`);
-        }
 
-        setIsSubmitting(false);
-      }}
-      validate={(values) => validate(values, imageFile)}
-      validateOnChange={false}
-      validateOnBlur={false}
-    >
-      {({ errors }) => (
-        <Form className="mt-4 flex flex-1 flex-col justify-between lg:max-w-2xl">
-          <div className={'space-y-3'}>
-            {delegatedPercent > 0 && (
-              <p className={'text-red-600'}>
-                You are currently delegating{' '}
-                <span className={'font-bold'}>{delegatedPercent}%</span> of your locked CELO. You
-                can still register as a delegatee, but consider undelegating. You can delegate only
-                CELO that you locked, not CELO that is delegated to you.
-              </p>
-            )}
-            <div className={'flex flex-col space-y-0.5'}>
-              <label htmlFor={'address'} className="text-xs font-semibold">
-                Address
-              </label>
-              <p className={'font-bold'}>{defaultFormValues?.address}</p>
-              <p className={'text-xs'}>
-                Your connected wallet address is provided automatically and cannot be changed. If
-                you want to use different address, open a pull request manually on{' '}
-                <Link href="https://github.com/celo-org/celo-mondo">Github</Link>.
-              </p>
-            </div>
-            <div className={'flex flex-col space-y-0.5'}>
-              <label htmlFor={'address'} className="text-xs font-semibold">
-                Name
-              </label>
-              <TextField
-                name="name"
-                placeholder="Your name"
-                defaultValue={defaultFormValues?.name}
-              />
-              {errors.name && <p className={'text-xs text-red-500'}>{errors.name}</p>}
-            </div>
-            <div className={'flex flex-col space-y-0.5'}>
-              <label htmlFor={'interests'} className="text-xs font-semibold">
-                Interests
-              </label>
-              <TextField
-                name="interests"
-                placeholder="Blockchain, NFTs"
-                defaultValue={defaultFormValues?.interests}
-              />
-              {errors.interests && <p className={'text-xs text-red-500'}>{errors.interests}</p>}
-              <p className={'text-xs'}>
-                Provide a comma separated list of your interests, at least one is required.
-              </p>
-            </div>
-            <div className={'flex flex-col space-y-0.5'}>
-              <label htmlFor={'description'} className="text-xs font-semibold">
-                Description
-              </label>
-              <TextField
-                name="description"
-                placeholder="Your description"
-                defaultValue={defaultFormValues?.description}
-              />
-              {errors.description && <p className={'text-xs text-red-500'}>{errors.description}</p>}
-              <p className={'text-xs'}>Provide a short description of yourself.</p>
-            </div>
-            <div className={'flex flex-col space-y-0.5'}>
-              <label htmlFor={'twitterUrl'} className="text-xs font-semibold">
-                Twitter
-              </label>
-              <TextField
-                name="twitterUrl"
-                placeholder="https://x.com/celo"
-                defaultValue={defaultFormValues?.twitterUrl}
-              />
-              {errors.twitterUrl && <p className={'text-xs text-red-500'}>{errors.twitterUrl}</p>}
-              <p className={'text-xs'}>Provide a link to your X (formerly Twitter) profile.</p>
-            </div>
-            <div className={'flex flex-col space-y-0.5'}>
-              <label htmlFor={'websiteUrl'} className="text-xs font-semibold">
-                Website
-              </label>
-              <TextField
-                name="websiteUrl"
-                placeholder="https://celo.org/"
-                defaultValue={defaultFormValues?.websiteUrl}
-              />
-              {errors.websiteUrl && <p className={'text-xs text-red-500'}>{errors.websiteUrl}</p>}
-              <p className={'text-xs'}>Provide a link to your website.</p>
-            </div>
-            <div className={'flex flex-col space-y-0.5'}>
-              <label htmlFor={'verificationUrl'} className="text-xs font-semibold">
-                Verification Link
-              </label>
-              <TextField
-                name="verificationUrl"
-                placeholder="https://celo.org/"
-                defaultValue={defaultFormValues?.verificationUrl}
-              />
-              {errors.verificationUrl && (
-                <p className={'text-xs text-red-500'}>{errors.verificationUrl}</p>
+          try {
+            signature = await signForm({
+              ...values,
+              address: address!,
+              image: imageFile,
+            });
+          } catch (err) {
+            setIsSubmitting(false);
+
+            toast.error('Error while signing message');
+            logger.error(err);
+
+            return;
+          }
+
+          setIsSigning(false);
+
+          const request = new FormData();
+
+          request.append('image', imageFile as Blob);
+          request.append('name', values.name);
+          request.append('interests', values.interests);
+          request.append('description', values.description);
+          request.append('signature', signature);
+
+          if (values.twitterUrl) {
+            request.append('twitterUrl', values.twitterUrl);
+          }
+
+          if (values.websiteUrl) {
+            request.append('websiteUrl', values.websiteUrl);
+          }
+
+          request.append('verificationUrl', values.verificationUrl);
+          request.append('address', address!);
+
+          try {
+            const httpResponse = await fetch('/delegate/api/register', {
+              method: 'POST',
+              body: request,
+            });
+
+            if (httpResponse.ok) {
+              const response = (await httpResponse.json()) as RegisterDelegateResponse;
+
+              if (response.status === RegisterDelegateResponseStatus.Success) {
+                setPullRequestUrl(response.pullRequestUrl);
+              } else {
+                toast.error(response.message);
+              }
+            } else {
+              toast.error('Error while registering delegatee');
+            }
+          } catch (err) {
+            toast.error(`Error while registering delegatee: ${(err as Error).message}`);
+          }
+
+          setIsSubmitting(false);
+        }}
+        validate={(values) => validate(values, imageFile)}
+        validateOnChange={false}
+        validateOnBlur={false}
+      >
+        {({ errors }) => (
+          <Form className="mt-4 flex flex-1 flex-col justify-between lg:max-w-2xl">
+            <div className={'space-y-3'}>
+              {delegatedPercent > 0 && (
+                <p className={'text-red-600'}>
+                  You are currently delegating{' '}
+                  <span className={'font-bold'}>{delegatedPercent}%</span> of your locked CELO. You
+                  can still register as a delegatee, but consider undelegating. You can delegate
+                  only CELO that you locked, not CELO that is delegated to you.
+                </p>
               )}
-              <p className={'text-xs'}>
-                Provide a URL to proof authenticity of your delegatee registration, it can be a link
-                to a tweet, a forum post etc.
-              </p>
-            </div>
-            <div className={'flex flex-col space-y-0.5'}>
-              <label htmlFor={'websiteUrl'} className="text-xs font-semibold">
-                Image
-              </label>
-              <div className={'flex items-center'}>
-                {imageUrl && (
-                  <div className="mr-5">
-                    <ImageOrIdenticon imgSrc={imageUrl} address={address!} size={90} />
-                  </div>
-                )}
-                <input type="file" name="image" onChange={handleFileChange} />
+              <div className={'flex flex-col space-y-0.5'}>
+                <label htmlFor={'address'} className="text-xs font-semibold">
+                  Address
+                </label>
+                <p className={'font-bold'}>{defaultFormValues?.address}</p>
+                <p className={'text-xs'}>
+                  Your connected wallet address is provided automatically and cannot be changed. If
+                  you want to use different address, open a pull request manually on{' '}
+                  <Link href="https://github.com/celo-org/celo-mondo">Github</Link>.
+                </p>
               </div>
-              {errors.image! && <p className={'text-xs text-red-500'}>{errors.image!}</p>}
-              <p className={'text-xs'}>Provide an image to use as your delegate logo.</p>
+              <div className={'flex flex-col space-y-0.5'}>
+                <label htmlFor={'address'} className="text-xs font-semibold">
+                  Name
+                </label>
+                <TextField
+                  name="name"
+                  placeholder="Your name"
+                  defaultValue={defaultFormValues?.name}
+                />
+                {errors.name && <p className={'text-xs text-red-500'}>{errors.name}</p>}
+              </div>
+              <div className={'flex flex-col space-y-0.5'}>
+                <label htmlFor={'interests'} className="text-xs font-semibold">
+                  Interests
+                </label>
+                <TextField
+                  name="interests"
+                  placeholder="Blockchain, NFTs"
+                  defaultValue={defaultFormValues?.interests}
+                />
+                {errors.interests && <p className={'text-xs text-red-500'}>{errors.interests}</p>}
+                <p className={'text-xs'}>
+                  Provide a comma separated list of your interests, at least one is required.
+                </p>
+              </div>
+              <div className={'flex flex-col space-y-0.5'}>
+                <label htmlFor={'description'} className="text-xs font-semibold">
+                  Description
+                </label>
+                <TextField
+                  name="description"
+                  placeholder="Your description"
+                  defaultValue={defaultFormValues?.description}
+                />
+                {errors.description && (
+                  <p className={'text-xs text-red-500'}>{errors.description}</p>
+                )}
+                <p className={'text-xs'}>Provide a short description of yourself.</p>
+              </div>
+              <div className={'flex flex-col space-y-0.5'}>
+                <label htmlFor={'twitterUrl'} className="text-xs font-semibold">
+                  Twitter
+                </label>
+                <TextField
+                  name="twitterUrl"
+                  placeholder="https://x.com/celo"
+                  defaultValue={defaultFormValues?.twitterUrl}
+                />
+                {errors.twitterUrl && <p className={'text-xs text-red-500'}>{errors.twitterUrl}</p>}
+                <p className={'text-xs'}>Provide a link to your X (formerly Twitter) profile.</p>
+              </div>
+              <div className={'flex flex-col space-y-0.5'}>
+                <label htmlFor={'websiteUrl'} className="text-xs font-semibold">
+                  Website
+                </label>
+                <TextField
+                  name="websiteUrl"
+                  placeholder="https://celo.org/"
+                  defaultValue={defaultFormValues?.websiteUrl}
+                />
+                {errors.websiteUrl && <p className={'text-xs text-red-500'}>{errors.websiteUrl}</p>}
+                <p className={'text-xs'}>Provide a link to your website.</p>
+              </div>
+              <div className={'flex flex-col space-y-0.5'}>
+                <label htmlFor={'verificationUrl'} className="text-xs font-semibold">
+                  Verification Link
+                </label>
+                <TextField
+                  name="verificationUrl"
+                  placeholder="https://celo.org/"
+                  defaultValue={defaultFormValues?.verificationUrl}
+                />
+                {errors.verificationUrl && (
+                  <p className={'text-xs text-red-500'}>{errors.verificationUrl}</p>
+                )}
+                <p className={'text-xs'}>
+                  Provide a URL to proof authenticity of your delegatee registration, it can be a
+                  link to a tweet, a forum post etc.
+                </p>
+              </div>
+              <div className={'flex flex-col space-y-0.5'}>
+                <label htmlFor={'websiteUrl'} className="text-xs font-semibold">
+                  Image
+                </label>
+                <div className={'flex items-center'}>
+                  {imageUrl && (
+                    <div className="mr-5">
+                      <ImageOrIdenticon imgSrc={imageUrl} address={address!} size={90} />
+                    </div>
+                  )}
+                  <input type="file" name="image" onChange={handleFileChange} />
+                </div>
+                {errors.image! && <p className={'text-xs text-red-500'}>{errors.image!}</p>}
+                <p className={'text-xs'}>Provide an image to use as your delegate logo.</p>
+              </div>
+              <div className="space-y-2">
+                <SolidButtonWithSpinner
+                  type="submit"
+                  isLoading={isSubmitting}
+                  loadingText={isSigning ? 'Signing' : 'Submitting'}
+                >
+                  Sign and submit
+                </SolidButtonWithSpinner>
+                <p className={'text-xs'}>
+                  Upon submission, you will be first asked to sign a message with your wallet.
+                </p>
+              </div>
             </div>
-            <div className="space-y-2">
-              <SolidButtonWithSpinner
-                type="submit"
-                isLoading={isSubmitting}
-                loadingText={isSigning ? 'Signing' : 'Submitting'}
-              >
-                Sign and submit
-              </SolidButtonWithSpinner>
-              <p className={'text-xs'}>
-                Upon submission, you will be first asked to sign a message with your wallet.
-              </p>
-            </div>
-          </div>
-        </Form>
-      )}
-    </Formik>
+          </Form>
+        )}
+      </Formik>
+      <SafeModal isModalOpen={isModalOpen} close={closeModal} values={formDataValues} />
+    </>
   );
+}
+
+function SafeModal({
+  isModalOpen,
+  close,
+  values,
+}: {
+  values: RegisterDelegateFormValues | {};
+  isModalOpen: boolean;
+  close: () => void;
+}) {
+  return (
+    <Modal isOpen={isModalOpen} close={close}>
+      <div className="max-w-36[rem] flex min-h-[24rem] min-w-[18rem] flex-col border border-taupe-300 bg-taupe-100 p-2.5 pt-8">
+        <h2 className="font-serif text-xl">Registering from SAFE Instructions</h2>
+        <p className="my-4">
+          The Connected Address Appears to be a SAFE wallet. There are bugs related to registering
+          (but not acting as) a delegatee.
+        </p>
+        <p className="mb-4">
+          Please Follow{' '}
+          <a className="link" href="/docs/delegating-as-safe.md">
+            These Instructions to register
+          </a>
+        </p>
+        <hr />
+        <h3 className="mb-4 mt-4 text-sm">
+          Your Data (note that this format differs slightly from the requirements)
+        </h3>
+        <pre>{JSON.stringify(values, null, 2)}</pre>
+        <br />
+      </div>
+    </Modal>
+  );
+}
+
+function useSafeModal() {
+  const { isModalOpen, openModal, closeModal } = useModal();
+  const [values, setValues] = useState<RegisterDelegateFormValues | {}>({});
+
+  function openModalWithValues(_values: RegisterDelegateFormValues) {
+    setValues(_values);
+    openModal();
+  }
+
+  return {
+    isModalOpen,
+    openModal: openModalWithValues,
+    closeModal,
+    values,
+  };
 }

--- a/src/features/delegation/DelegateSafeWalletModal.tsx
+++ b/src/features/delegation/DelegateSafeWalletModal.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { Modal, useModal } from 'src/components/menus/Modal';
+import { delegateeRegistrationRequestToMetadata } from 'src/features/delegation/delegateeMetadata';
+import { RegisterDelegateFormValues } from 'src/features/delegation/types';
+import { useConfig, useConnections } from 'wagmi';
+
+export function DelegateSafeWalletModal({
+  isModalOpen,
+  close,
+  values,
+}: {
+  values: RegisterDelegateFormValues | {};
+  isModalOpen: boolean;
+  close: () => void;
+}) {
+  return (
+    <Modal isOpen={isModalOpen} close={close}>
+      <div className="max-w-36[rem] flex min-h-[24rem] min-w-[18rem] flex-col border border-taupe-300 bg-taupe-100 p-2.5 pt-8">
+        <h2 className="font-serif text-xl">Registering from SAFE Instructions</h2>
+        <p className="my-4">
+          The Connected Address Appears to be a SAFE wallet. There are bugs related to registering
+          (but not acting as) a delegatee.
+        </p>
+        <p className="mb-4">
+          Please Follow{' '}
+          <a className="link" href={'/docs/delegating-as-safe.md'}>
+            These Instructions to register
+          </a>
+        </p>
+        <hr />
+        <h3 className="mb-4 mt-4 text-sm">Use the following JSON in your PR.</h3>
+        <pre className="bg-white p-2">
+          {isModalOpen && Object.prototype.hasOwnProperty.call(values, 'image')
+            ? JSON.stringify(
+                delegateeRegistrationRequestToMetadata(
+                  values as RegisterDelegateFormValues,
+                  new Date(),
+                ),
+                null,
+                2,
+              )
+            : null}
+        </pre>
+        <br />
+      </div>
+    </Modal>
+  );
+}
+export function useSAFEModal() {
+  const { isModalOpen, openModal, closeModal } = useModal();
+  const [values, setValues] = useState<RegisterDelegateFormValues | {}>({});
+
+  function openModalWithValues(_values: RegisterDelegateFormValues) {
+    setValues(_values);
+    openModal();
+  }
+
+  return {
+    isModalOpen,
+    openModal: openModalWithValues,
+    closeModal,
+    values,
+  };
+}
+
+export const useIsSAFEWallet = () => {
+  const config = useConfig();
+  const [connection] = useConnections();
+  const safeConnector = config.connectors.find((x) => x.id === 'safe')!;
+  const isSafe = connection?.connector === safeConnector;
+  return isSafe;
+};

--- a/src/features/delegation/hooks/useSIgnedData.ts
+++ b/src/features/delegation/hooks/useSIgnedData.ts
@@ -1,6 +1,6 @@
 import { EIP712Delegatee, RegisterDelegateFormValues } from 'src/features/delegation/types';
 import { sha256 } from 'viem';
-import { useSignTypedData } from 'wagmi';
+import { useConfig, useConnections, useSignTypedData } from 'wagmi';
 
 export function useSignedData() {
   const { signTypedDataAsync } = useSignTypedData();
@@ -21,3 +21,11 @@ export function useSignedData() {
     });
   };
 }
+
+export const useIsSAFEWallet = () => {
+  const config = useConfig();
+  const [connection] = useConnections();
+  const safeConnector = config.connectors.find((x) => x.id === 'safe')!;
+  const isSafe = connection?.connector === safeConnector;
+  return isSafe;
+};

--- a/src/features/delegation/hooks/useSignedData.ts
+++ b/src/features/delegation/hooks/useSignedData.ts
@@ -1,6 +1,6 @@
 import { EIP712Delegatee, RegisterDelegateFormValues } from 'src/features/delegation/types';
 import { sha256 } from 'viem';
-import { useConfig, useConnections, useSignTypedData } from 'wagmi';
+import { useSignTypedData } from 'wagmi';
 
 export function useSignedData() {
   const { signTypedDataAsync } = useSignTypedData();
@@ -21,11 +21,3 @@ export function useSignedData() {
     });
   };
 }
-
-export const useIsSAFEWallet = () => {
-  const config = useConfig();
-  const [connection] = useConnections();
-  const safeConnector = config.connectors.find((x) => x.id === 'safe')!;
-  const isSafe = connection?.connector === safeConnector;
-  return isSafe;
-};


### PR DESCRIPTION
## Description

This is a workaround to help SAFE users register as delegates via a PR 

if it detects a safe is connected instead of signing it shows them instructions

The instructions link to a plain markdownfile (i figure for something temp it makes sense for it to be gritty)


#### other
rename  file with a typo in its name

## QA
create a safe
add either local host or this prs preview url as custom app
inside of the safe navigate to the delegate register page 
fill out form
click sign
see the modal with json for pr and link to instructions

## relates

#154 