### PR TITLE
Fix 205 - separate out ineligible groups and fetch their votes too

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,12 +33,14 @@ function HeroSection({ totalVotes, groups }: { totalVotes?: bigint; groups?: Val
     let minVotes = BigInt(1e40);
     let numValidators = 0;
     for (const g of groups) {
+      if (!g.eligible) continue;
       numValidators += objLength(g.members);
       const numElectedMembers = Object.values(g.members).filter(
         (m) => m.status === ValidatorStatus.Elected,
       ).length;
-      if (!numElectedMembers) continue;
+      if (!numElectedMembers || g.votes === 0n) continue;
       const votesPerMember = g.votes / BigInt(numElectedMembers);
+
       minVotes = bigIntMin(minVotes, votesPerMember);
     }
     return { minVotes, numValidators };

--- a/src/features/validators/ValidatorGroupTable.tsx
+++ b/src/features/validators/ValidatorGroupTable.tsx
@@ -30,9 +30,10 @@ import { bigIntSum, mean, sum } from 'src/utils/math';
 const NUM_COLLAPSED_GROUPS = 9;
 const DESKTOP_ONLY_COLUMNS = ['votes', 'avgScore', 'numElected', 'cta'];
 enum Filter {
-  All = 'All',
+  All = 'All Eligible',
   Elected = 'Elected',
   Unelected = 'Unelected',
+  Ineligible = 'Ineligible',
 }
 
 export function ValidatorGroupTable({
@@ -75,9 +76,10 @@ export function ValidatorGroupTable({
 
   const headerCounts = useMemo<Record<Filter, number>>(() => {
     return {
-      [Filter.All]: groups.length,
+      [Filter.All]: groups.filter((g) => g.eligible).length,
       [Filter.Elected]: groups.filter((g) => isElected(g)).length,
       [Filter.Unelected]: groups.filter((g) => !isElected(g)).length,
+      [Filter.Ineligible]: groups.filter((g) => !g.eligible).length,
     };
   }, [groups]);
 
@@ -340,7 +342,8 @@ function useTableRows({
       .filter((g) => {
         if (filter === Filter.Elected) return isElected(g);
         else if (filter === Filter.Unelected) return !isElected(g);
-        else return true;
+        else if (filter === Filter.Ineligible) return !g.eligible;
+        else return g.eligible;
       })
       .filter(
         (g) =>

--- a/src/features/validators/useValidatorGroups.ts
+++ b/src/features/validators/useValidatorGroups.ts
@@ -112,7 +112,6 @@ async function fetchValidatorGroupInfo(publicClient: PublicClient) {
     group.eligible = true;
     group.capacity = getValidatorGroupCapacity(group, validatorAddrs.length, totalLocked);
   }
-  // note this modifies the groups object
   const groupsWithIneligibleVotes = await setVotesForIneligibleGroups(publicClient, groups);
 
   return { groups: groupsWithIneligibleVotes, addressToGroup: groups, totalLocked, totalVotes };

--- a/src/features/validators/useValidatorGroups.ts
+++ b/src/features/validators/useValidatorGroups.ts
@@ -128,7 +128,6 @@ async function setVotesForIneligibleGroups(
   const ineligibleGroups = Object.values(groups)
     .filter((g) => g.votes === 0n)
     .filter((g) => g.eligible === false);
-  // .filter((g) => electedSignersSet.union(new Set(Object.keys(g.members))).size > 0);
 
   if (ineligibleGroups.length > 0) {
     const activeVotesIneligibleGroups = await fetchActiveVotesForGroups(


### PR DESCRIPTION
Groups that are not eligible to receive votes previously where shown as just regular normal groups. They should be separated out so people dont vote for them but can still see them to revoke their votes. 


* Change all to All Eligible
* ensure we skip ineligible or withoutvotes when getting min votes 



<img width="1302" alt="Screenshot 2025-03-26 at 12 48 00" src="https://github.com/user-attachments/assets/d309bb84-a275-4a38-9aac-3d54b4ca58f5" />

