### PR TITLE
fix: prevent text-wrapping in proposals

### DIFF
--- a/src/features/governance/components/ProposalCard.tsx
+++ b/src/features/governance/components/ProposalCard.tsx
@@ -156,6 +156,8 @@ function IdBadge({ cgp, id }: { cgp?: number; id?: number }) {
   if (!cgp && !id) return null;
   const idValue = cgp ? `CGP ${cgp}` : `# ${id}`;
   return (
-    <div className="rounded-full border border-taupe-300 px-2 text-sm font-light">{idValue}</div>
+    <div className="whitespace-nowrap rounded-full border border-taupe-300 px-2 text-sm font-light">
+      {idValue}
+    </div>
   );
 }

--- a/src/features/governance/components/StageBadge.tsx
+++ b/src/features/governance/components/StageBadge.tsx
@@ -15,7 +15,7 @@ export function StageBadge({
   return (
     <div
       style={{ backgroundColor: color }}
-      className={clsx('rounded-full px-2 py-0.5 text-sm font-light', className)}
+      className={clsx('whitespace-nowrap rounded-full px-2 py-0.5 text-sm font-light', className)}
     >
       {label}
     </div>


### PR DESCRIPTION
Fixes the pills taking two lines when the text is a bit longer (happens with `Approval Pending` mostly). Doesn't text-wrap the date so there's no overflow-x

## general 

- [x] no lint or test errors

[Fixes #216]

![Screenshot 2025-04-14 at 17 20 31](https://github.com/user-attachments/assets/edeefe3d-0f32-484d-befe-51e792b19b7b)
