### PR TITLE
Allow Voting in Elections and on Proposals as a Vote Signer

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -6,7 +6,7 @@ import { SolidButton } from 'src/components/buttons/SolidButton';
 import { TabHeaderButton } from 'src/components/buttons/TabHeaderButton';
 import { Section } from 'src/components/layout/Section';
 import { Amount, formatNumberString } from 'src/components/numbers/Amount';
-import { useBalance } from 'src/features/account/hooks';
+import { useBalance, useVoteSignerToAccount } from 'src/features/account/hooks';
 import { DelegationsTable } from 'src/features/delegation/components/DelegationsTable';
 import { useDelegatees } from 'src/features/delegation/hooks/useDelegatees';
 import { useDelegationBalances } from 'src/features/delegation/hooks/useDelegationBalances';
@@ -31,6 +31,7 @@ import { useValidatorGroups } from 'src/features/validators/useValidatorGroups';
 import LockIcon from 'src/images/icons/lock.svg';
 import UnlockIcon from 'src/images/icons/unlock.svg';
 import WithdrawIcon from 'src/images/icons/withdraw.svg';
+import { shortenAddress } from 'src/utils/addresses';
 import { usePageInvariant } from 'src/utils/navigation';
 import useTabs from 'src/utils/useTabs';
 import { useAccount } from 'wagmi';
@@ -40,14 +41,15 @@ export default function Page() {
   const address = account?.address;
   usePageInvariant(!!address, '/');
 
-  const { balance: walletBalance } = useBalance(address);
-  const { lockedBalances } = useLockedStatus(address);
-  const { delegations } = useDelegationBalances(address);
+  const { signingFor, isVoteSigner } = useVoteSignerToAccount(address);
+  const { balance: walletBalance } = useBalance(signingFor);
+  const { lockedBalances } = useLockedStatus(signingFor);
+  const { delegations } = useDelegationBalances(signingFor);
   const { addressToDelegatee } = useDelegatees();
-  const { stakeBalances, groupToStake, refetch: refetchStakes } = useStakingBalances(address);
-  const { totalRewardsWei, groupToReward } = useStakingRewards(address, groupToStake);
+  const { stakeBalances, groupToStake, refetch: refetchStakes } = useStakingBalances(signingFor);
+  const { totalRewardsWei, groupToReward } = useStakingRewards(signingFor, groupToStake);
   const { groupToIsActivatable, refetch: refetchActivations } = usePendingStakingActivations(
-    address,
+    signingFor,
     groupToStake,
   );
   const { addressToGroup } = useValidatorGroups();
@@ -64,12 +66,20 @@ export default function Page() {
   return (
     <Section className="mt-6" containerClassName="space-y-6 px-4">
       <h1 className="hidden font-serif text-3xl sm:block">Dashboard</h1>
-      <div className="flex items-center justify-between md:gap-x-40">
+      <div className="items-top flex justify-between md:gap-x-40">
         <div>
           <h2>Total Balance</h2>
           <Amount valueWei={totalBalance} className="-mt-1 text-3xl md:text-4xl" />
         </div>
-        <LockButtons className="hidden md:flex" />
+        {isVoteSigner ? (
+          <div className="align-right flex flex-col items-end">
+            <h2 className="font-medium">Vote Signer For</h2>
+            <span className="hidden font-mono text-sm md:flex">{signingFor}</span>
+            <span className="font-mono text-sm md:hidden">{shortenAddress(signingFor!)}</span>
+          </div>
+        ) : (
+          <LockButtons className="hidden md:flex" />
+        )}
       </div>
       <AccountStats
         walletBalance={walletBalance}
@@ -78,7 +88,7 @@ export default function Page() {
         totalRewards={totalRewardsWei}
         totalDelegated={totalDelegated}
       />
-      <LockButtons className="flex justify-between md:hidden" />
+      {isVoteSigner || <LockButtons className="flex justify-between md:hidden" />}
       <TableTabs
         groupToStake={groupToStake}
         addressToGroup={addressToGroup}

--- a/src/features/account/hooks.ts
+++ b/src/features/account/hooks.ts
@@ -2,7 +2,7 @@ import { accountsABI, lockedGoldABI } from '@celo/abis';
 import { validatorsABI } from '@celo/abis-12';
 import { useEffect, useState } from 'react';
 import { useToastError } from 'src/components/notifications/useToastError';
-import { BALANCE_REFRESH_INTERVAL, ZERO_ADDRESS } from 'src/config/consts';
+import { BALANCE_REFRESH_INTERVAL, StaleTime, ZERO_ADDRESS } from 'src/config/consts';
 import { Addresses } from 'src/config/contracts';
 import { isCel2 } from 'src/utils/is-cel2';
 import { isNullish } from 'src/utils/typeof';
@@ -47,22 +47,39 @@ export function useLockedBalance(address?: Address) {
   };
 }
 
-export function useVoteSigner(address?: Address, isRegistered?: boolean) {
+export function useGetVoteSignerFor(address?: Address) {
+  return useReadContract({
+    address: Addresses.Accounts,
+    abi: accountsABI,
+    functionName: 'getVoteSigner',
+    args: [address || ZERO_ADDRESS],
+    query: {
+      enabled: !!address,
+    },
+  });
+}
+
+// will return address it is authorized to vote on behalf of or itself if it is a registered account
+export function useVoteSignerToAccount(address: Address | undefined) {
+  const isRegistered = useIsAccount(address);
   const {
-    data: voteSigner,
+    data: account,
     isError,
     isLoading,
+    isFetched,
     refetch,
   } = useReadContract({
     address: Addresses.Accounts,
     abi: accountsABI,
     functionName: 'voteSignerToAccount',
     args: [address || ZERO_ADDRESS],
+    scopeKey: `voteSignerToAccount-${address}`,
     query: {
-      enabled: isRegistered === false,
-      // The contract will revert if given address is both:
-      // - not registered
-      // - not a vote signer
+      staleTime: StaleTime.Long,
+      enabled: isRegistered.isFetched && isRegistered.data === false,
+      // The contract will revert if given address is neither
+      // - authorized to vote for any accounts (but is authorized for some other role)
+      // - or not registered
       // and hence we don't need to retry in this case, otherwise
       // we'll retry up to 3 times
       retry: (failureCount: number, error: ReadContractErrorType) => {
@@ -74,11 +91,11 @@ export function useVoteSigner(address?: Address, isRegistered?: boolean) {
       },
     },
   });
-
   return {
-    voteSigner,
+    signingFor: isRegistered.data ? address : account,
     isError,
     isLoading,
+    isFetched: isFetched,
     refetch,
   };
 }
@@ -86,13 +103,7 @@ export function useVoteSigner(address?: Address, isRegistered?: boolean) {
 // Note, this retrieves the address' info from the Accounts contract
 // It has nothing to do with wallets or backend services
 export function useAccountDetails(address?: Address) {
-  const isAccountResult = useReadContract({
-    address: Addresses.Accounts,
-    abi: accountsABI,
-    functionName: 'isAccount',
-    args: [address || ZERO_ADDRESS],
-    query: { enabled: !!address },
-  });
+  const isAccountResult = useIsAccount(address);
 
   const isValidatorResult = useReadContract({
     address: Addresses.Validators,
@@ -132,6 +143,16 @@ export function useAccountDetails(address?: Address) {
         isValidatorGroupResult.refetch(),
       ]),
   };
+}
+
+export function useIsAccount(address: Address | undefined) {
+  return useReadContract({
+    address: Addresses.Accounts,
+    abi: accountsABI,
+    functionName: 'isAccount',
+    args: [address || ZERO_ADDRESS],
+    query: { enabled: !!address },
+  });
 }
 
 export function useIsCel2() {

--- a/src/features/account/hooks.ts
+++ b/src/features/account/hooks.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useToastError } from 'src/components/notifications/useToastError';
 import { BALANCE_REFRESH_INTERVAL, StaleTime, ZERO_ADDRESS } from 'src/config/consts';
 import { Addresses } from 'src/config/contracts';
+import { eqAddress } from 'src/utils/addresses';
 import { isCel2 } from 'src/utils/is-cel2';
 import { isNullish } from 'src/utils/typeof';
 import { ReadContractErrorType } from 'viem';
@@ -92,7 +93,8 @@ export function useVoteSignerToAccount(address: Address | undefined) {
     },
   });
   return {
-    signingFor: isRegistered.data ? address : account,
+    signingFor: isRegistered.data ? address : account || address,
+    isVoteSigner: account && address && !eqAddress(account, address),
     isError,
     isLoading,
     isFetched: isFetched,

--- a/src/features/delegation/DelegationForm.test.tsx
+++ b/src/features/delegation/DelegationForm.test.tsx
@@ -144,7 +144,7 @@ const setupHooks = (options?: SetupHooksOptions) => {
     isLoading: false,
   } as any);
 
-  vi.spyOn(hooks, 'useVoteSigner').mockReturnValue({
+  vi.spyOn(hooks, 'useVoteSignerToAccount').mockReturnValue({
     isLoading: false,
     voteSigner: options?.isRegistered === true ? TEST_ADDRESSES[0] : options?.voteSignerForAddress,
   } as any);

--- a/src/features/delegation/DelegationForm.tsx
+++ b/src/features/delegation/DelegationForm.tsx
@@ -5,7 +5,7 @@ import { RadioField } from 'src/components/input/RadioField';
 import { RangeField } from 'src/components/input/RangeField';
 import { TextField } from 'src/components/input/TextField';
 import { MAX_NUM_DELEGATEES, ZERO_ADDRESS } from 'src/config/consts';
-import { useAccountDetails, useVoteSigner } from 'src/features/account/hooks';
+import { useAccountDetails, useVoteSignerToAccount } from 'src/features/account/hooks';
 import { getDelegateTxPlan } from 'src/features/delegation/delegatePlan';
 import { useDelegatees } from 'src/features/delegation/hooks/useDelegatees';
 import { useDelegationBalances } from 'src/features/delegation/hooks/useDelegationBalances';
@@ -43,11 +43,11 @@ export function DelegationForm({
 }) {
   const { address } = useAccount();
   const { addressToDelegatee } = useDelegatees();
-  const { isValidator, isValidatorGroup, isRegistered } = useAccountDetails(address);
-  const { voteSigner } = useVoteSigner(address, isRegistered);
-  const { delegations, refetch } = useDelegationBalances(address, voteSigner);
+  const { isValidator, isValidatorGroup } = useAccountDetails(address);
+  const { signingFor } = useVoteSignerToAccount(address);
+  const { delegations, refetch } = useDelegationBalances(address, signingFor);
   const { isValidator: isVoteSignerForValidator, isValidatorGroup: isVoteSignerForValidatorGroup } =
-    useAccountDetails(voteSigner);
+    useAccountDetails(signingFor);
 
   const { getNextTx, txPlanIndex, numTxs, isPlanStarted, onTxSuccess } =
     useTransactionPlan<DelegateFormValues>({

--- a/src/features/governance/hooks/useProposalQuorum.test.ts
+++ b/src/features/governance/hooks/useProposalQuorum.test.ts
@@ -55,7 +55,7 @@ describe('fetchThresholds', () => {
         0.6,
       ]
     `);
-    expect(spy.mock.results[0].value).resolves.toHaveLength(Number(expectedNumberOfTxs));
+    await expect(spy.mock.results[0].value).resolves.toHaveLength(Number(expectedNumberOfTxs));
     expect(spy.mock.calls.length).toBe(2);
   });
 
@@ -70,7 +70,7 @@ describe('fetchThresholds', () => {
     await expect(
       fetchThresholds(publicArchiveClient, proposalId, expectedNumberOfTxs),
     ).resolves.toMatchSnapshot();
-    expect(spy.mock.results[0].value).resolves.toHaveLength(Number(expectedNumberOfTxs));
+    await expect(spy.mock.results[0].value).resolves.toHaveLength(Number(expectedNumberOfTxs));
     expect(spy.mock.calls.length).toBe(2);
   });
 });

--- a/src/features/staking/StakeForm.tsx
+++ b/src/features/staking/StakeForm.tsx
@@ -12,6 +12,7 @@ import {
   MIN_GROUP_SCORE_FOR_RANDOM,
   ZERO_ADDRESS,
 } from 'src/config/consts';
+import { useVoteSignerToAccount } from 'src/features/account/hooks';
 import { useDelegationBalances } from 'src/features/delegation/hooks/useDelegationBalances';
 import { LockedBalances } from 'src/features/locking/types';
 import { useLockedStatus } from 'src/features/locking/useLockedStatus';
@@ -58,9 +59,10 @@ export function StakeForm({
 }) {
   const { address } = useAccount();
   const { groups, addressToGroup } = useValidatorGroups();
-  const { lockedBalances } = useLockedStatus(address);
-  const { stakeBalances, groupToStake, refetch } = useStakingBalances(address);
-  const { delegations } = useDelegationBalances(address);
+  const { signingFor } = useVoteSignerToAccount(address);
+  const { lockedBalances } = useLockedStatus(signingFor);
+  const { stakeBalances, groupToStake, refetch } = useStakingBalances(signingFor);
+  const { delegations } = useDelegationBalances(address, signingFor);
 
   const onPlanSuccess = (v: StakeFormValues, r: TransactionReceipt) => {
     if (v.action === StakeActionType.Stake) {
@@ -114,7 +116,7 @@ export function StakeForm({
       validateOnBlur={false}
     >
       {({ values }) => (
-        <Form className="mt-4 flex flex-1 flex-col justify-between">
+        <Form className="mt-4 flex flex-1 flex-col justify-between" data-testid="stake-form">
           {/* Reserve space for group menu */}
           <div className="min-h-[21.5rem] space-y-4">
             <ActionTypeField defaultAction={defaultFormValues?.action} disabled={isInputDisabled} />

--- a/src/features/transactions/TransactionFlow.test.tsx
+++ b/src/features/transactions/TransactionFlow.test.tsx
@@ -136,14 +136,14 @@ describe('<TransactionFlow />', () => {
     describe('as a vote signer', () => {
       // Should not make "an exception" for any other form type than delegation
       // although in the future we should allow it
-      test('does not render <VoteForm /> for a vote signer with no account', async () => {
+      test('does renders <VoteForm />', async () => {
         setupHooks({ voteSignerForAddress: TEST_ADDRESSES[1] });
 
         const flow = render(
           <TransactionFlow header="Test header" FormComponent={VoteForm} closeModal={() => {}} />,
         );
 
-        await waitFor(async () => expect(await flow.findByTestId('register-form')).toBeTruthy());
+        await waitFor(async () => expect(await flow.findByTestId('vote-form')).toBeTruthy());
       });
     });
     describe('as a account which has been delegated votes', () => {
@@ -203,7 +203,7 @@ const setupHooks = (options?: SetupHooksOptions) => {
     isLoading: false,
   } as any);
 
-  vi.spyOn(hooks, 'useVoteSigner').mockReturnValue({
+  vi.spyOn(hooks, 'useVoteSignerToAccount').mockReturnValue({
     isLoading: false,
     voteSigner: options?.isRegistered === true ? TEST_ADDRESSES[0] : options?.voteSignerForAddress,
   } as any);

--- a/src/features/transactions/TransactionFlow.test.tsx
+++ b/src/features/transactions/TransactionFlow.test.tsx
@@ -136,7 +136,7 @@ describe('<TransactionFlow />', () => {
     describe('as a vote signer', () => {
       // Should not make "an exception" for any other form type than delegation
       // although in the future we should allow it
-      test('does renders <VoteForm />', async () => {
+      test('renders <VoteForm />', async () => {
         setupHooks({ voteSignerForAddress: TEST_ADDRESSES[1] });
 
         const flow = render(
@@ -198,6 +198,12 @@ const setupHooks = (options?: SetupHooksOptions) => {
     isRegistered: options?.isRegistered === true || false,
   } as any);
 
+  vi.spyOn(hooks, 'useIsAccount').mockReturnValue({
+    isError: false,
+    isLoading: false,
+    data: options?.isRegistered === true || false,
+  } as any);
+
   vi.spyOn(hooks, 'useLockedBalance').mockReturnValue({
     lockedBalance: options?.lockedGoldBalance || 0n,
     isLoading: false,
@@ -205,6 +211,6 @@ const setupHooks = (options?: SetupHooksOptions) => {
 
   vi.spyOn(hooks, 'useVoteSignerToAccount').mockReturnValue({
     isLoading: false,
-    voteSigner: options?.isRegistered === true ? TEST_ADDRESSES[0] : options?.voteSignerForAddress,
+    signingFor: options?.isRegistered === true ? TEST_ADDRESSES[0] : options?.voteSignerForAddress,
   } as any);
 };

--- a/src/features/transactions/TransactionFlow.test.tsx
+++ b/src/features/transactions/TransactionFlow.test.tsx
@@ -2,11 +2,14 @@ import { render, waitFor } from '@testing-library/react';
 import * as hooks from 'src/features/account/hooks';
 import { DelegationForm } from 'src/features/delegation/DelegationForm';
 import * as useDelegatees from 'src/features/delegation/hooks/useDelegatees';
+import * as useValidatorGroups from 'src/features/validators/useValidatorGroups';
+
 import * as useDelegationBalances from 'src/features/delegation/hooks/useDelegationBalances';
 import * as useGovernanceProposals from 'src/features/governance/hooks/useGovernanceProposals';
 import * as votingHooks from 'src/features/governance/hooks/useVotingStatus';
 import { VoteForm } from 'src/features/governance/VoteForm';
 import * as useLockedStatus from 'src/features/locking/useLockedStatus';
+import { StakeForm } from 'src/features/staking/StakeForm';
 import * as useStakingBalances from 'src/features/staking/useStakingBalances';
 import { TransactionFlow } from 'src/features/transactions/TransactionFlow';
 import * as useWriteContractWithReceipt from 'src/features/transactions/useWriteContractWithReceipt';
@@ -158,6 +161,48 @@ describe('<TransactionFlow />', () => {
       });
     });
   });
+
+  describe('<StakeForm/>', () => {
+    describe('for registered account', () => {
+      test('renders <LockForm /> for account with no locked balance', async () => {
+        setupHooks({ isRegistered: true });
+
+        const flow = render(
+          <TransactionFlow header="Test header" FormComponent={StakeForm} closeModal={() => {}} />,
+        );
+
+        await waitFor(async () => {
+          expect(await flow.findByTestId('lock-form')).toBeTruthy();
+        });
+      });
+
+      test('renders <StakeForm /> for account with some locked balance', async () => {
+        setupHooks({ isRegistered: true, lockedGoldBalance: 1n });
+
+        const flow = render(
+          <TransactionFlow header="Election" FormComponent={StakeForm} closeModal={() => {}} />,
+        );
+
+        await waitFor(async () => expect(await flow.findByTestId('stake-form')).toBeTruthy());
+      });
+    });
+    describe('for voteSigner', () => {
+      test('renders <StakeForm /> for account with some locked balance', async () => {
+        setupHooks({
+          isRegistered: false,
+          lockedGoldBalance: 0n,
+          votingPower: 2n,
+          voteSignerForAddress: TEST_ADDRESSES[1],
+        });
+
+        const flow = render(
+          <TransactionFlow header="Election" FormComponent={StakeForm} closeModal={() => {}} />,
+        );
+
+        await waitFor(async () => expect(await flow.findByTestId('stake-form')).toBeTruthy());
+      });
+    });
+  });
 });
 
 type SetupHooksOptions = {
@@ -185,6 +230,7 @@ const setupHooks = (options?: SetupHooksOptions) => {
   vi.spyOn(useStakingBalances, 'useStakingBalances').mockReturnValue({} as any);
   vi.spyOn(useGovernanceProposals, 'useGovernanceProposals').mockReturnValue({} as any);
   vi.spyOn(useGovernanceProposals, 'useGovernanceProposal').mockReturnValue({} as any);
+  vi.spyOn(useValidatorGroups, 'useValidatorGroups').mockReturnValue({} as any);
 
   vi.spyOn(votingHooks, 'useGovernanceVotingPower').mockReturnValue({
     isLoading: false,

--- a/src/features/transactions/TransactionFlow.tsx
+++ b/src/features/transactions/TransactionFlow.tsx
@@ -38,6 +38,8 @@ export function TransactionFlow<FormDefaults extends {}>({
     signingForAccount &&
     signingForAccount !== address;
 
+  console.info(FormComponent.name, 'signingForAccount', signingForAccount, address);
+
   const votingPower = useGovernanceVotingPower(address);
 
   const hasVotingPower =

--- a/src/features/transactions/TransactionFlow.tsx
+++ b/src/features/transactions/TransactionFlow.tsx
@@ -2,7 +2,6 @@ import { FunctionComponent, ReactNode, useCallback, useState } from 'react';
 import { SpinnerWithLabel } from 'src/components/animation/Spinner';
 import { AccountRegisterForm } from 'src/features/account/AccountRegisterForm';
 import { useIsAccount, useLockedBalance, useVoteSignerToAccount } from 'src/features/account/hooks';
-import { DelegationForm } from 'src/features/delegation/DelegationForm';
 import { useGovernanceVotingPower } from 'src/features/governance/hooks/useVotingStatus';
 import { VoteForm } from 'src/features/governance/VoteForm';
 import { LockForm } from 'src/features/locking/LockForm';
@@ -14,7 +13,7 @@ import { useAccount } from 'wagmi';
 export interface TransactionFlowProps<FormDefaults extends {} = {}> {
   header: string;
   FormComponent: FunctionComponent<{ onConfirmed: OnConfirmedFn; defaultFormValues: FormDefaults }>;
-  requiresLockedFunds?: boolean;
+  requiresLockedFundsOrVoteSigner?: boolean;
   defaultFormValues?: FormDefaults;
 }
 
@@ -23,7 +22,7 @@ export interface TransactionFlowProps<FormDefaults extends {} = {}> {
 export function TransactionFlow<FormDefaults extends {}>({
   header,
   FormComponent,
-  requiresLockedFunds = true,
+  requiresLockedFundsOrVoteSigner = true,
   defaultFormValues = {} as FormDefaults,
   closeModal,
 }: TransactionFlowProps<FormDefaults> & { closeModal: () => void }) {
@@ -33,12 +32,7 @@ export function TransactionFlow<FormDefaults extends {}>({
     useVoteSignerToAccount(address);
   const { lockedBalance } = useLockedBalance(address);
   const { confirmationDetails, onConfirmed } = useTransactionFlowConfirmation();
-  const isDelegatingOrVotingAsVoteSigner =
-    (FormComponent.name === DelegationForm.name || FormComponent.name === VoteForm.name) &&
-    signingForAccount &&
-    signingForAccount !== address;
-
-  console.info(FormComponent.name, 'signingForAccount', signingForAccount, address);
+  const isVoteSigner = Boolean(signingForAccount && signingForAccount !== address);
 
   const votingPower = useGovernanceVotingPower(address);
 
@@ -57,12 +51,12 @@ export function TransactionFlow<FormDefaults extends {}>({
     votingPower.isLoading
   ) {
     Component = <SpinnerWithLabel className="py-20">Loading account data...</SpinnerWithLabel>;
-  } else if (!isRegistered && !isDelegatingOrVotingAsVoteSigner) {
+  } else if (!isRegistered && !isVoteSigner) {
     Component = <AccountRegisterForm refetchAccountDetails={refetchAccountDetails} />;
   } else if (
     lockedBalance <= 0n &&
-    requiresLockedFunds &&
-    !isDelegatingOrVotingAsVoteSigner &&
+    requiresLockedFundsOrVoteSigner &&
+    !isVoteSigner &&
     !willVoteAndHasVotingPower
   ) {
     Component = <LockForm showTip={true} />;

--- a/src/features/transactions/TransactionFlowType.ts
+++ b/src/features/transactions/TransactionFlowType.ts
@@ -18,26 +18,26 @@ export const transactionFlowProps: Record<TransactionFlowType, TransactionFlowPr
   [TransactionFlowType.Lock]: {
     FormComponent: LockForm,
     header: 'Lock CELO',
-    requiresLockedFunds: false,
+    requiresLockedFundsOrVoteSigner: false,
   },
   [TransactionFlowType.Stake]: {
     FormComponent: StakeForm,
     header: 'Stake CELO',
-    requiresLockedFunds: true,
+    requiresLockedFundsOrVoteSigner: true,
   },
   [TransactionFlowType.Upvote]: {
     FormComponent: UpvoteForm,
     header: 'Upvote proposal',
-    requiresLockedFunds: true,
+    requiresLockedFundsOrVoteSigner: true,
   },
   [TransactionFlowType.Vote]: {
     FormComponent: VoteForm,
     header: 'Vote for proposal',
-    requiresLockedFunds: true,
+    requiresLockedFundsOrVoteSigner: true,
   },
   [TransactionFlowType.Delegate]: {
     FormComponent: DelegationForm,
     header: 'Delegate CELO',
-    requiresLockedFunds: true,
+    requiresLockedFundsOrVoteSigner: true,
   },
 };

--- a/src/features/wallet/WalletDropdown.tsx
+++ b/src/features/wallet/WalletDropdown.tsx
@@ -1,17 +1,20 @@
 import { useConnectModal } from '@rainbow-me/rainbowkit';
+import clsx from 'clsx';
 import Link from 'next/link';
 import { OutlineButton, OutlineButtonClassName } from 'src/components/buttons/OutlineButton';
 import { SolidButton } from 'src/components/buttons/SolidButton';
 import { Identicon } from 'src/components/icons/Identicon';
 import { DropdownModal } from 'src/components/menus/Dropdown';
 import { Amount } from 'src/components/numbers/Amount';
+import { ShortAddress } from 'src/components/text/ShortAddress';
+import { useGovernanceVotingPower } from 'src/features/governance/hooks/useVotingStatus';
 import { useStakingRewards } from 'src/features/staking/rewards/useStakingRewards';
 import { useStakingBalances } from 'src/features/staking/useStakingBalances';
 import { shortenAddress } from 'src/utils/addresses';
 import { useCopyHandler } from 'src/utils/clipboard';
 import { logger } from 'src/utils/logger';
 import { useAccount, useDisconnect } from 'wagmi';
-import { useBalance, useLockedBalance } from '../account/hooks';
+import { useBalance, useLockedBalance, useVoteSignerToAccount } from '../account/hooks';
 
 export function WalletDropdown() {
   const { address, isConnected } = useAccount();
@@ -60,14 +63,18 @@ function DropdownContent({
   disconnect: () => any;
   close: () => void;
 }) {
+  const { signingFor } = useVoteSignerToAccount(address);
   const { balance: walletBalance } = useBalance(address);
-  const { lockedBalance } = useLockedBalance(address);
-  const { groupToStake } = useStakingBalances(address);
-  const { totalRewards } = useStakingRewards(address, groupToStake);
+  const { votingPower } = useGovernanceVotingPower(signingFor);
+  const { lockedBalance } = useLockedBalance(signingFor);
+  const { groupToStake } = useStakingBalances(signingFor);
+  const { totalRewards } = useStakingRewards(signingFor, groupToStake);
 
   const totalBalance = (walletBalance || 0n) + (lockedBalance || 0n);
 
   const onClickCopy = useCopyHandler(address);
+
+  const isAVoteSigner = signingFor && signingFor !== address;
 
   return (
     <div className="flex min-w-[18rem] flex-col items-center space-y-3">
@@ -77,14 +84,44 @@ function DropdownContent({
           {shortenAddress(address)}
         </button>
       </div>
-      <div className="flex flex-col items-center">
-        <label className="text-sm">Total Balance</label>
-        <Amount valueWei={totalBalance} className="text-2xl" />
-      </div>
+      {isAVoteSigner ? (
+        <div className="flex flex-col items-center">
+          <label className="font-italic text-sm italic">Votes on Behalf of </label>
+          <span className="text-sm">
+            <ShortAddress address={signingFor} />
+          </span>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center">
+          <label className="text-sm"> Total Balance</label>
+          <Amount valueWei={totalBalance} className="text-2xl" />
+        </div>
+      )}
+
       <div className="flex w-full flex-col justify-stretch divide-y divide-taupe-300 border border-taupe-300">
-        <ValueRow label="Wallet Balance" valueWei={walletBalance} />
-        <ValueRow label="Total Locked" valueWei={lockedBalance} />
-        <ValueRow label="Total Earned" value={totalRewards} />
+        <ValueRow
+          label="Wallet Balance"
+          address={isAVoteSigner ? address : undefined}
+          valueWei={walletBalance}
+        />
+        <ValueRow
+          isHighlighted={isAVoteSigner}
+          label="Voting Power"
+          address={isAVoteSigner ? signingFor : undefined}
+          valueWei={votingPower}
+        />
+        <ValueRow
+          isHighlighted={isAVoteSigner}
+          label="Total Locked"
+          address={isAVoteSigner ? signingFor : undefined}
+          valueWei={lockedBalance}
+        />
+        <ValueRow
+          isHighlighted={isAVoteSigner}
+          label="Total Earned"
+          address={isAVoteSigner ? signingFor : undefined}
+          value={totalRewards}
+        />
       </div>
       <div className="flex w-full items-center justify-between space-x-4">
         <Link href="/account">
@@ -100,14 +137,23 @@ function ValueRow({
   label,
   value,
   valueWei,
+  address,
+  isHighlighted,
 }: {
+  isHighlighted?: boolean;
+  address?: Address;
   label: string;
   value?: number;
   valueWei?: bigint;
 }) {
   return (
-    <div className="flex flex-col px-3 py-2.5">
-      <label className="text-sm">{label}</label>
+    <div className={clsx('flex flex-col px-3 py-2.5', isHighlighted && 'bg-taupe-100')}>
+      <div className="flex flex-row justify-between">
+        <label className="text-sm">{label} </label>
+        {address && (
+          <span className="font-mono text-xs text-taupe-600">&hellip;{address?.slice(-4)}</span>
+        )}
+      </div>
       <Amount value={value} valueWei={valueWei} className="text-xl" />
     </div>
   );

--- a/src/features/wallet/WalletDropdown.tsx
+++ b/src/features/wallet/WalletDropdown.tsx
@@ -63,7 +63,7 @@ function DropdownContent({
   disconnect: () => any;
   close: () => void;
 }) {
-  const { signingFor } = useVoteSignerToAccount(address);
+  const { signingFor, isVoteSigner } = useVoteSignerToAccount(address);
   const { balance: walletBalance } = useBalance(address);
   const { votingPower } = useGovernanceVotingPower(signingFor);
   const { lockedBalance } = useLockedBalance(signingFor);
@@ -74,8 +74,6 @@ function DropdownContent({
 
   const onClickCopy = useCopyHandler(address);
 
-  const isAVoteSigner = signingFor && signingFor !== address;
-
   return (
     <div className="flex min-w-[18rem] flex-col items-center space-y-3">
       <div className="flex flex-col items-center">
@@ -84,11 +82,11 @@ function DropdownContent({
           {shortenAddress(address)}
         </button>
       </div>
-      {isAVoteSigner ? (
+      {isVoteSigner ? (
         <div className="flex flex-col items-center">
           <label className="font-italic text-sm italic">Votes on Behalf of </label>
           <span className="text-sm">
-            <ShortAddress address={signingFor} />
+            <ShortAddress address={signingFor!} />
           </span>
         </div>
       ) : (
@@ -101,25 +99,25 @@ function DropdownContent({
       <div className="flex w-full flex-col justify-stretch divide-y divide-taupe-300 border border-taupe-300">
         <ValueRow
           label="Wallet Balance"
-          address={isAVoteSigner ? address : undefined}
+          address={isVoteSigner ? address : undefined}
           valueWei={walletBalance}
         />
         <ValueRow
-          isHighlighted={isAVoteSigner}
+          isHighlighted={isVoteSigner}
           label="Voting Power"
-          address={isAVoteSigner ? signingFor : undefined}
+          address={isVoteSigner ? signingFor : undefined}
           valueWei={votingPower}
         />
         <ValueRow
-          isHighlighted={isAVoteSigner}
+          isHighlighted={isVoteSigner}
           label="Total Locked"
-          address={isAVoteSigner ? signingFor : undefined}
+          address={isVoteSigner ? signingFor : undefined}
           valueWei={lockedBalance}
         />
         <ValueRow
-          isHighlighted={isAVoteSigner}
+          isHighlighted={isVoteSigner}
           label="Total Earned"
-          address={isAVoteSigner ? signingFor : undefined}
+          address={isVoteSigner ? signingFor : undefined}
           value={totalRewards}
         />
       </div>

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -34,7 +34,7 @@ export function shortenAddress(address: string, capitalize = true) {
   const start = normalizedAddress.substring(0, 6);
   const end = normalizedAddress.substring(address.length - 4);
 
-  const shortened = `${start}...${end}`;
+  const shortened = `${start}…${end}`;
   return capitalize ? capitalizeAddress(shortened) : shortened;
 }
 


### PR DESCRIPTION
## what
Connected Addresses that have been granted voting rights for another account can now vote on proposals and for validators via mondo

### details 
* voting for elections
* voting on proposals
* wallet dropdown now shows specific vote signer info
* account dashboard specifies you are a vote signer
* accidentally fixed that when an account had delegated all celo  the "you must lock celo" dialogue would show even when the account had locked celo

### Tested

* new tests
* verified a normal account still works fine

## issues
fixes #152 


<img width="360" alt="Screenshot 2025-05-07 at 12 00 08" src="https://github.com/user-attachments/assets/86a035da-6a52-448e-9220-a3138664a3a5" />
<img width="727" alt="Screenshot 2025-05-07 at 12 24 32" src="https://github.com/user-attachments/assets/4235c54a-ad13-40d9-a34f-a27a18467674" />
<img width="302" alt="Screenshot 2025-05-07 at 12 24 56" src="https://github.com/user-attachments/assets/3b229a79-6e5a-40c1-a837-802f89fac913" />
