### PR TITLE
Prevent decimals from being passed to big into

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -61,7 +61,7 @@ export default function Page() {
 
   const totalLocked = getTotalLockedCelo(lockedBalances);
   const totalBalance = (walletBalance || 0n) + totalLocked;
-  const totalDelegated = (BigInt(delegations?.totalPercent || 0) * totalLocked) / 100n;
+  const totalDelegated = (BigInt(Math.round(delegations?.totalPercent || 0)) * totalLocked) / 100n;
 
   return (
     <Section className="mt-6" containerClassName="space-y-6 px-4">


### PR DESCRIPTION
number must not have decimals or big Int throws


Fixes (assuming there isnt another spot this could be happening but its hard to tell with only this info)

![image](https://github.com/user-attachments/assets/e171a836-c322-4a01-8761-3aa57f573bfa)
