### PR TITLE
feat: display bridge descriptions as inline text instead of tooltips

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -65,12 +65,10 @@ function BridgeLink({ name, operator, href, logo, description }: Bridge) {
     <div className="flex items-center justify-between border border-taupe-300 bg-white p-4 sm:gap-32 sm:p-5">
       <div className="flex items-center space-x-4">
         <Image src={logo} width={60} height={60} alt="" className="rounded-full" />
-        <div className="flex flex-col">
+        <div className="flex flex-col gap-1">
           <h2 className="font-serif text-xl">{name}</h2>
-          <div className="flex flex-row gap-2">
-            <h3 className="text-sm">{`By ${operator}`}</h3>
-            <HelpIcon text={description} type="tooltip" />
-          </div>
+          <h3 className="text-sm">{`By ${operator}`}</h3>
+          <p className='text-sm'>{description}</p>
         </div>
       </div>
       <SolidButton className="all:p-0">

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -61,13 +61,13 @@ export default function Page() {
 
 function BridgeLink({ name, operator, href, logo, description }: Bridge) {
   return (
-    <div className="flex items-center justify-between border border-taupe-300 bg-white mx-auto max-w-xl p-4 sm:p-5">
+    <div className="mx-auto flex max-w-xl items-center justify-between border border-taupe-300 bg-white p-4 sm:p-5">
       <div className="flex items-center space-x-4">
         <Image src={logo} width={60} height={60} alt="" className="rounded-full" />
         <div className="flex flex-col gap-1">
           <h2 className="font-serif text-xl">{name}</h2>
           <h3 className="text-sm">{`By ${operator}`}</h3>
-          <p className='text-sm'>{description}</p>
+          <p className="text-sm">{description}</p>
         </div>
       </div>
       <SolidButton className="all:p-0">

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -61,7 +61,7 @@ export default function Page() {
 
 function BridgeLink({ name, operator, href, logo, description }: Bridge) {
   return (
-    <div className="flex items-center justify-between border border-taupe-300 bg-white p-4 sm:gap-32 sm:p-5">
+    <div className="flex items-center justify-between border border-taupe-300 bg-white mx-auto max-w-xl p-4 sm:p-5">
       <div className="flex items-center space-x-4">
         <Image src={logo} width={60} height={60} alt="" className="rounded-full" />
         <div className="flex flex-col gap-1">

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 import { A_Blank } from 'src/components/buttons/A_Blank';
 import { SolidButton } from 'src/components/buttons/SolidButton';
 import { ChevronIcon } from 'src/components/icons/Chevron';
-import { HelpIcon } from 'src/components/icons/HelpIcon';
 import { Section } from 'src/components/layout/Section';
 import { H1 } from 'src/components/text/headers';
 import { config } from 'src/config/config';

--- a/src/features/validators/useValidatorGroups.ts
+++ b/src/features/validators/useValidatorGroups.ts
@@ -134,7 +134,7 @@ async function fetchValidatorGroupInfo(publicClient: PublicClient) {
   groups_.forEach((group, i) => {
     group.score = fromFixidity(groupScores[i]);
   });
-  console.log(groupScores);
+
   validators_.forEach((validator, i) => {
     validator.score = fromFixidity(validatorScores[i]);
   });


### PR DESCRIPTION
This PR resolves issue #254  Replacing tooltip-based descriptions with always-visible inline text for each bridge option in the "Bridge to Celo" section.