### PR TITLE
Update delegate/validator profile information (clemens.eth / atweb3)

### DIFF
--- a/src/config/delegatees/0x9c868c1A597d08C76406E012f6EBf44A42864D75.json
+++ b/src/config/delegatees/0x9c868c1A597d08C76406E012f6EBf44A42864D75.json
@@ -5,7 +5,8 @@
   "date": "2024-11-05",
   "links": {
     "website": "https://celo.clemens.fi",
-    "twitter": "https://x.com/clemensvienna"
+    "twitter": "https://x.com/clemensvienna",
+    "github": "https://github.com/cleot"
   },
   "interests": [
     "Node Operator",

--- a/src/config/delegates.json
+++ b/src/config/delegates.json
@@ -419,7 +419,8 @@
     "date": "2024-11-05",
     "links": {
       "website": "https://celo.clemens.fi",
-      "twitter": "https://x.com/clemensvienna"
+      "twitter": "https://x.com/clemensvienna",
+      "github": "https://github.com/cleot"
     },
     "interests": [
       "Node Operator",

--- a/src/config/validators.ts
+++ b/src/config/validators.ts
@@ -347,6 +347,7 @@ export const VALIDATOR_GROUPS: Record<string, ValidatorInfo> = {
     logo: '/logos/validators/atweb3.jpg',
     links: {
       website: 'https://atweb3.co',
+      twitter: 'https://x.com/atweb3_gmbh',
     },
   },
   '0xD19FB36B7F433fe13820767ef6d0E26FDbaB68CC': {


### PR DESCRIPTION
- More proof will be added once the PR is opened and include a signed message to this PR. (Edit: Proof added)

Proof:

clemens.eth / 0x9c868c1A597d08C76406E012f6EBf44A42864D75 delegate profile: https://etherscan.io/verifySig/278515 (0x9299cd0e958217414a317f13e09378ca51307a7a71dc756325c37b2e6d442671260497217270712b4ad2f99cf7d73f37cc357ff5b896d14c2b49befc1f88ad351b)
atweb3 validator: Domain change can be verified by cnofirming the redirect from https://atweb3.io to https://atweb3.co in the browser.
