### PR TITLE
Remove toTitleCase for validator/group name for display

### DIFF
--- a/src/features/delegation/DelegationForm.tsx
+++ b/src/features/delegation/DelegationForm.tsx
@@ -20,7 +20,7 @@ import { LockedBalances } from 'src/features/locking/types';
 import { OnConfirmedFn } from 'src/features/transactions/types';
 import { useTransactionPlan } from 'src/features/transactions/useTransactionPlan';
 import { useWriteContractWithReceipt } from 'src/features/transactions/useWriteContractWithReceipt';
-import { cleanGroupName } from 'src/features/validators/utils';
+import { cleanDelegateeName } from 'src/features/validators/utils';
 
 import { isValidAddress, shortenAddress } from 'src/utils/addresses';
 import { objLength } from 'src/utils/objects';
@@ -192,7 +192,7 @@ function DelegateeField({
   }, [fieldName, defaultValue, setFieldValue]);
 
   const currentDelegatee = addressToDelegatee?.[values[fieldName]];
-  const delegateeName = cleanGroupName(currentDelegatee?.name || '');
+  const delegateeName = cleanDelegateeName(currentDelegatee?.name || '');
 
   return (
     <div className="relative flex flex-col space-y-1.5">

--- a/src/features/validators/utils.ts
+++ b/src/features/validators/utils.ts
@@ -8,6 +8,10 @@ export function findGroup(groups?: ValidatorGroup[], address?: Address) {
 }
 
 export function cleanGroupName(name: string) {
+  return trimToLength(name.replace(/group|Group/g, '').replace(/[-_]/g, ' '), 20);
+}
+
+export function cleanDelegateeName(name: string) {
   return trimToLength(toTitleCase(name.replace(/group|Group/g, '').replace(/[-_]/g, ' ')), 20);
 }
 


### PR DESCRIPTION
Adds new function cleanDelegateeName for delegate display that retains title case for human names Fixes #287

# Please Read and check all that apply 

## general 

- [x] no lint or test errors


