### PR TITLE
feat: add CeloPG as community contributor

### DIFF
--- a/src/config/validators.ts
+++ b/src/config/validators.ts
@@ -491,6 +491,7 @@ export const VALIDATOR_GROUPS: Record<string, ValidatorInfo> = {
       website: 'https://www.celopg.eco/',
       twitter: 'https://x.com/CeloPublicGoods',
     },
+    communityContributor: true,
   },
   '0xd42Bb7FE32cDf68045f49553c6f851fD2c58B6a9': {
     logo: '/logos/validators/celo-colombia.png',


### PR DESCRIPTION
Mark Celo Public Goods (0x6F769BcC21A867b839b6cA59dDe6c6C90c1DF18D) as a community contributor to display the community contributor badge in recognition of their contributions through Celo Gather and other builder acceleration programs.

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)


