### PR TITLE
Update bridge urls

### DIFF
--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -30,7 +30,7 @@ const BRIDGES: Bridge[] = [
   {
     name: 'Squid Router',
     operator: 'Squid',
-    href: 'https://app.squidrouter.com/?chains=42220%2C1&tokens=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE%2C0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    href: 'https://app.squidrouter.com/?chains=42220%2C1&tokens=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
     logo: SquidLogo,
     description:
       'Axelar based cross chain DEX. Good for moving stablecoins between chains, or swapping directly between assets.',


### PR DESCRIPTION
Update Bridge URLs to Preselect Celo as Source Chain
Description
Updated all bridge URLs on the /bridge page to preselect Celo as the source chain and include appropriate default tokens. This improves user experience by reducing the number of clicks needed to bridge assets from Celo.

Changes

Bridge | Updated URL Parameters
-- | --
Superbridge | ?fromChainId=42220&toChainId=1
Squid Router | ?chains=42220,1&tokens=<native_celo>,<native_eth>
Jumper | ?fromChain=42220&fromToken=<CELO>&toChain=1&toToken=<ETH>
Portal Bridge | ?fromChain=Celo&toChain=Ethereum&fromToken=CELO
USDT0 | ?source=celo&destination=ethereum&token=usdt0