### PR TITLE
Update bridge links to default to bridging into Celo

### DIFF
--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -46,7 +46,7 @@ const BRIDGES: Bridge[] = [
   {
     name: 'Portal Bridge',
     operator: 'Wormhole',
-    href: 'https://portalbridge.com/?fromChain=Ethereum&toChain=Celo&fromToken=ETH&toToken=WETH',
+    href: 'https://portalbridge.com/?fromChain=Ethereum&toChain=Celo&fromToken=ETH&toToken=0x66803FB87aBd4aaC3cbB3fAd7C3aa01f6F3FB207',
     logo: PortalLogo,
     description: 'Wormhole based bridge. Good for wormhole assets on Celo.',
   },


### PR DESCRIPTION
## Summary
- Swap source/destination parameters on all five bridge providers (Superbridge, Squid Router, Jumper, Portal Bridge, USDT0) so they default to bridging assets **into** Celo rather than out of Celo.

## Test plan
- [ ] Verify each bridge link opens with Celo as the destination chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)