### PR TITLE
fix(governance): self-heal proposals incorrectly marked as Expired

### DIFF
--- a/src/scripts/updateProposalStages.test.ts
+++ b/src/scripts/updateProposalStages.test.ts
@@ -1,0 +1,176 @@
+import { eq } from 'drizzle-orm';
+import database from 'src/config/database';
+import { eventsTable, proposalsTable } from 'src/db/schema';
+import { ProposalStage, VoteType } from 'src/features/governance/types';
+import { TEST_CHAIN_ID } from 'src/test/database';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { updateProposalStages } from './updateProposalStages';
+
+// Mock getOnChainQuorumRequired since it makes complex RPC calls
+vi.mock('src/features/governance/utils/quorum', () => ({
+  getOnChainQuorumRequired: vi.fn().mockResolvedValue({ quorumVotesRequired: 100n }),
+}));
+
+function createMockClient(getProposalStageResponses: Record<number, ProposalStage>) {
+  return {
+    chain: { id: TEST_CHAIN_ID },
+    readContract: vi.fn().mockImplementation(({ args }: { args: [bigint] }) => {
+      const proposalId = Number(args[0]);
+      const stage = getProposalStageResponses[proposalId];
+      if (stage === undefined) {
+        throw new Error(`No mock response for proposal ${proposalId}`);
+      }
+      return Promise.resolve(stage);
+    }),
+  } as any;
+}
+
+function insertProposal(
+  overrides: Partial<typeof proposalsTable.$inferInsert> & { id: number; stage: ProposalStage },
+) {
+  return database.insert(proposalsTable).values({
+    author: 'test',
+    cgp: overrides.id,
+    chainId: TEST_CHAIN_ID,
+    timestamp: 1753277605,
+    title: `Proposal ${overrides.id}`,
+    ...overrides,
+  });
+}
+
+function insertProposalExecutedEvent(proposalId: number) {
+  // Use proposalId to generate a unique tx hash (PK includes eventName + txHash + chainId)
+  const txHash = `0x${proposalId.toString(16).padStart(64, '0')}` as `0x${string}`;
+  return database.insert(eventsTable).values({
+    chainId: TEST_CHAIN_ID,
+    eventName: 'ProposalExecuted',
+    args: { proposalId: String(proposalId) },
+    address: '0x0000000000000000000000000000000000000000',
+    topics: ['0xabc123' as `0x${string}`, txHash],
+    data: '0x' as `0x${string}`,
+    blockNumber: 59165954n,
+    transactionHash: txHash,
+  });
+}
+
+async function getProposalStage(proposalId: number): Promise<ProposalStage> {
+  const [row] = await database
+    .select({ stage: proposalsTable.stage })
+    .from(proposalsTable)
+    .where(eq(proposalsTable.id, proposalId));
+  return row.stage;
+}
+
+describe('updateProposalStages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('self-heals: Expiration → Executed when ProposalExecuted event exists', async () => {
+    // Proposal is stuck as Expiration in DB (the bug scenario)
+    await insertProposal({ id: 275, stage: ProposalStage.Expiration, transactionCount: 3 });
+    // But a ProposalExecuted event exists in the events table
+    await insertProposalExecutedEvent(275);
+
+    // On-chain returns Expiration (5) because data was zeroed after execution
+    const client = createMockClient({ 275: ProposalStage.Expiration });
+
+    await updateProposalStages(client);
+
+    expect(await getProposalStage(275)).toBe(ProposalStage.Executed);
+  });
+
+  it('prevents: Execution → Executed (not Expiration) when ProposalExecuted event exists', async () => {
+    // Proposal is in Execution stage, just got executed on-chain
+    await insertProposal({ id: 100, stage: ProposalStage.Execution, transactionCount: 2 });
+    await insertProposalExecutedEvent(100);
+
+    // Contract returns Expiration because data was zeroed
+    const client = createMockClient({ 100: ProposalStage.Expiration });
+
+    await updateProposalStages(client);
+
+    expect(await getProposalStage(100)).toBe(ProposalStage.Executed);
+  });
+
+  it('marks genuine expiration when no ProposalExecuted event exists', async () => {
+    await insertProposal({ id: 50, stage: ProposalStage.Execution, transactionCount: 1 });
+
+    // Contract returns Expiration and there's no ProposalExecuted event
+    const client = createMockClient({ 50: ProposalStage.Expiration });
+
+    await updateProposalStages(client);
+
+    expect(await getProposalStage(50)).toBe(ProposalStage.Expiration);
+  });
+
+  it('marks as Rejected when expired with more No votes than Yes', async () => {
+    await insertProposal({ id: 60, stage: ProposalStage.Execution, transactionCount: 1 });
+
+    // Insert votes: more No than Yes
+    await database.insert((await import('src/db/schema')).votesTable).values([
+      { proposalId: 60, type: VoteType.Yes, count: 10n, chainId: TEST_CHAIN_ID },
+      { proposalId: 60, type: VoteType.No, count: 20n, chainId: TEST_CHAIN_ID },
+    ]);
+
+    const client = createMockClient({ 60: ProposalStage.Expiration });
+
+    await updateProposalStages(client);
+
+    expect(await getProposalStage(60)).toBe(ProposalStage.Rejected);
+  });
+
+  it('does not update when on-chain stage matches DB stage', async () => {
+    await insertProposal({ id: 70, stage: ProposalStage.Referendum });
+
+    // On-chain confirms same stage
+    const client = createMockClient({ 70: ProposalStage.Referendum });
+
+    await updateProposalStages(client);
+
+    expect(await getProposalStage(70)).toBe(ProposalStage.Referendum);
+  });
+
+  it('marks zero-transaction proposals as Adopted when leaving Execution', async () => {
+    await insertProposal({ id: 80, stage: ProposalStage.Execution, transactionCount: 0 });
+
+    // Contract returns Expiration, no executed event, zero txns → Adopted
+    const client = createMockClient({ 80: ProposalStage.Expiration });
+
+    await updateProposalStages(client);
+
+    expect(await getProposalStage(80)).toBe(ProposalStage.Adopted);
+  });
+
+  it('does not touch proposals in non-active stages (e.g. Executed, Queued)', async () => {
+    await insertProposal({ id: 90, stage: ProposalStage.Executed });
+    await insertProposal({ id: 91, stage: ProposalStage.Queued });
+
+    const client = createMockClient({});
+
+    await updateProposalStages(client);
+
+    // readContract should never be called since these proposals are filtered out
+    expect(client.readContract).not.toHaveBeenCalled();
+    expect(await getProposalStage(90)).toBe(ProposalStage.Executed);
+    expect(await getProposalStage(91)).toBe(ProposalStage.Queued);
+  });
+
+  it('self-heals multiple proposals in a single run', async () => {
+    await insertProposal({ id: 200, stage: ProposalStage.Expiration, transactionCount: 1 });
+    await insertProposal({ id: 201, stage: ProposalStage.Expiration, transactionCount: 2 });
+    await insertProposalExecutedEvent(200);
+    await insertProposalExecutedEvent(201);
+
+    const client = createMockClient({
+      200: ProposalStage.Expiration,
+      201: ProposalStage.Expiration,
+    });
+
+    await updateProposalStages(client);
+
+    expect(await getProposalStage(200)).toBe(ProposalStage.Executed);
+    expect(await getProposalStage(201)).toBe(ProposalStage.Executed);
+  });
+});

--- a/src/scripts/updateProposalStages.ts
+++ b/src/scripts/updateProposalStages.ts
@@ -2,36 +2,35 @@ import 'dotenv/config';
 
 /* eslint no-console: 0 */
 import { governanceABI } from '@celo/abis';
-import { and, eq, inArray, lt } from 'drizzle-orm';
+import { and, eq, inArray, lt, sql } from 'drizzle-orm';
 import { STAGING_MOCK_PROPOSALS_START_ID } from 'src/config/config';
 import { Addresses } from 'src/config/contracts';
 import database from 'src/config/database';
-import { proposalsTable } from 'src/db/schema';
+import { eventsTable, proposalsTable } from 'src/db/schema';
 import { getProposalVotes } from 'src/features/governance/getProposalVotes';
 import { ProposalStage, VoteType } from 'src/features/governance/types';
 import { getOnChainQuorumRequired } from 'src/features/governance/utils/quorum';
 import { Chain, createPublicClient, http, PublicClient, Transport } from 'viem';
 import { celo } from 'viem/chains';
 
-async function updateProposalStages() {
+export async function updateProposalStages(client: PublicClient<Transport, Chain>) {
   console.log('Starting proposal stage update...');
 
-  // Setup client using the same env var pattern as other scripts
-  const archiveNode = process.env.PRIVATE_NO_RATE_LIMITED_NODE!;
-  const client = createPublicClient({
-    chain: celo,
-    transport: http(archiveNode),
-  }) as PublicClient<Transport, Chain>;
-
-  // 1. Get all proposals in Referendum or Execution stages from DB
-  // These are the only stages that can transition without emitting events
+  // 1. Get all proposals in Referendum, Execution, or Expiration stages from DB
+  // Referendum/Execution can transition without emitting events.
+  // Expiration is included to self-heal proposals that were incorrectly marked as
+  // expired when they were actually executed (contract zeroes data after execution).
   const activeProposals = await database
     .select()
     .from(proposalsTable)
     .where(
       and(
         eq(proposalsTable.chainId, client.chain.id),
-        inArray(proposalsTable.stage, [ProposalStage.Referendum, ProposalStage.Execution]),
+        inArray(proposalsTable.stage, [
+          ProposalStage.Referendum,
+          ProposalStage.Execution,
+          ProposalStage.Expiration,
+        ]),
         lt(proposalsTable.id, STAGING_MOCK_PROPOSALS_START_ID),
       ),
     );
@@ -60,21 +59,41 @@ async function updateProposalStages() {
         `Proposal ${proposal.id}: DB stage=${proposal.stage}, On-chain stage=${onChainStage}`,
       );
 
-      //  4. Check if proposal should be marked as Rejected (off-chain only stage)
+      //  4. Check if proposal should be marked as Executed or Rejected (off-chain only stages)
+      //  After execution, the Governance contract zeroes all proposal data, causing
+      //  getProposalStage() to return Expiration (5) for executed proposals.
+      //  We must check for a ProposalExecuted event before concluding it expired.
       if (onChainStage === ProposalStage.Expiration) {
-        // Lazy-load votes only when we encounter an expired proposal
-        if (!allVotes) {
-          console.log('Found expired proposal, loading votes for Rejected calculation...');
-          allVotes = await getProposalVotes(client.chain.id);
-        }
+        const [executedEvent] = await database
+          .select({ id: eventsTable.transactionHash })
+          .from(eventsTable)
+          .where(
+            and(
+              eq(eventsTable.eventName, 'ProposalExecuted'),
+              eq(eventsTable.chainId, client.chain.id),
+              eq(sql`(${eventsTable.args}->>'proposalId')::bigint`, BigInt(proposal.id)),
+            ),
+          )
+          .limit(1);
 
-        const votes = allVotes[proposal.id];
-        if (votes) {
-          const yesVotes = votes[VoteType.Yes] || 0n;
-          const noVotes = votes[VoteType.No] || 0n;
-          if (noVotes > yesVotes) {
-            onChainStage = ProposalStage.Rejected;
-            console.log(`  → Marking as Rejected (No: ${noVotes}, Yes: ${yesVotes})`);
+        if (executedEvent) {
+          onChainStage = ProposalStage.Executed;
+          console.log(`  → Marking as Executed (found ProposalExecuted event)`);
+        } else {
+          // Lazy-load votes only when we encounter a truly expired proposal
+          if (!allVotes) {
+            console.log('Found expired proposal, loading votes for Rejected calculation...');
+            allVotes = await getProposalVotes(client.chain.id);
+          }
+
+          const votes = allVotes[proposal.id];
+          if (votes) {
+            const yesVotes = votes[VoteType.Yes] || 0n;
+            const noVotes = votes[VoteType.No] || 0n;
+            if (noVotes > yesVotes) {
+              onChainStage = ProposalStage.Rejected;
+              console.log(`  → Marking as Rejected (No: ${noVotes}, Yes: ${yesVotes})`);
+            }
           }
         }
       }
@@ -127,13 +146,21 @@ async function updateProposalStages() {
   }
 }
 
-// Run the script
-updateProposalStages()
-  .then(() => {
-    console.log('Script completed successfully');
-    process.exit(0);
-  })
-  .catch((error) => {
-    console.error('Script failed:', error);
-    process.exit(1);
-  });
+// Run the script when executed directly
+if (process.argv[1]?.endsWith('updateProposalStages.ts')) {
+  const archiveNode = process.env.PRIVATE_NO_RATE_LIMITED_NODE!;
+  const client = createPublicClient({
+    chain: celo,
+    transport: http(archiveNode),
+  }) as PublicClient<Transport, Chain>;
+
+  updateProposalStages(client)
+    .then(() => {
+      console.log('Script completed successfully');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('Script failed:', error);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
The Governance contract zeroes all proposal data after execution, causing getProposalStage() to return Expiration for executed proposals. The cron job blindly trusted this value, overwriting the correct Executed stage.

Now checks the events table for a ProposalExecuted event before concluding a proposal expired. Also queries proposals already stuck in Expiration so they self-heal on the next cron run.