### PR TITLE
fix(governance): self-heal just-executed proposals stuck as "Expired"

### DIFF
--- a/src/scripts/updateProposalStages.test.ts
+++ b/src/scripts/updateProposalStages.test.ts
@@ -13,17 +13,36 @@ vi.mock('src/features/governance/utils/quorum', () => ({
   getOnChainQuorumRequired: (...args: unknown[]) => mockGetOnChainQuorumRequired(...args),
 }));
 
-function createMockClient(getProposalStageResponses: Record<number, ProposalStage>) {
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const NON_ZERO_PROPOSER = '0x000000000000000000000000000000000000dEaD';
+
+function createMockClient(
+  getProposalStageResponses: Record<number, ProposalStage>,
+  // Proposal ids whose on-chain data is zeroed (i.e. were executed & deleted).
+  // getProposal returns a zero-address proposer for these. Any id not listed
+  // returns a non-zero proposer (genuinely expired but still present on-chain).
+  executedOnChainIds: number[] = [],
+) {
   return {
     chain: { id: TEST_CHAIN_ID },
-    readContract: vi.fn().mockImplementation(({ args }: { args: [bigint] }) => {
-      const proposalId = Number(args[0]);
-      const stage = getProposalStageResponses[proposalId];
-      if (stage === undefined) {
-        throw new Error(`No mock response for proposal ${proposalId}`);
-      }
-      return Promise.resolve(stage);
-    }),
+    readContract: vi
+      .fn()
+      .mockImplementation(({ functionName, args }: { functionName: string; args: [bigint] }) => {
+        const proposalId = Number(args[0]);
+
+        if (functionName === 'getProposal') {
+          const proposer = executedOnChainIds.includes(proposalId)
+            ? ZERO_ADDRESS
+            : NON_ZERO_PROPOSER;
+          return Promise.resolve([proposer, 0n, 0n, 0n, '', 0n, false]);
+        }
+
+        const stage = getProposalStageResponses[proposalId];
+        if (stage === undefined) {
+          throw new Error(`No mock response for proposal ${proposalId}`);
+        }
+        return Promise.resolve(stage);
+      }),
   } as any;
 }
 
@@ -95,6 +114,22 @@ describe('updateProposalStages', () => {
     expect(await getProposalStage(100)).toBe(ProposalStage.Executed);
   });
 
+  it('self-heals via on-chain check: Execution → Executed when data is zeroed but event not yet ingested', async () => {
+    // Race scenario: proposal was just executed. getProposalStage returns Expiration
+    // (data zeroed), but the hourly backfill has NOT yet ingested ProposalExecuted
+    // into the events table. Without the on-chain fallback this would wrongly show
+    // "Expired" for up to ~1 hour.
+    await insertProposal({ id: 295, stage: ProposalStage.Execution, transactionCount: 3 });
+
+    // No ProposalExecuted event in DB; on-chain stage is Expiration but proposal
+    // data is zeroed (proposer == 0x0) → it was executed, not expired.
+    const client = createMockClient({ 295: ProposalStage.Expiration }, [295]);
+
+    await updateProposalStages(client);
+
+    expect(await getProposalStage(295)).toBe(ProposalStage.Executed);
+  });
+
   it('marks genuine expiration when no ProposalExecuted event exists', async () => {
     await insertProposal({ id: 50, stage: ProposalStage.Execution, transactionCount: 1 });
 
@@ -104,6 +139,24 @@ describe('updateProposalStages', () => {
     await updateProposalStages(client);
 
     expect(await getProposalStage(50)).toBe(ProposalStage.Expiration);
+  });
+
+  it('prefers Rejected over on-chain-executed when No > Yes even if data is zeroed', async () => {
+    // Safety guard: a proposal's contract slot can be zeroed when its dequeue
+    // index is reused. A losing proposal (No > Yes) can never have been executed,
+    // so it must be marked Rejected, not mislabeled Executed from the zeroed slot.
+    await insertProposal({ id: 65, stage: ProposalStage.Execution, transactionCount: 1 });
+    await database.insert((await import('src/db/schema')).votesTable).values([
+      { proposalId: 65, type: VoteType.Yes, count: 5n, chainId: TEST_CHAIN_ID },
+      { proposalId: 65, type: VoteType.No, count: 30n, chainId: TEST_CHAIN_ID },
+    ]);
+
+    // On-chain stage Expiration AND data zeroed (proposer 0x0) — but votes say lost.
+    const client = createMockClient({ 65: ProposalStage.Expiration }, [65]);
+
+    await updateProposalStages(client);
+
+    expect(await getProposalStage(65)).toBe(ProposalStage.Rejected);
   });
 
   it('marks as Rejected when expired with more No votes than Yes', async () => {

--- a/src/scripts/updateProposalStages.ts
+++ b/src/scripts/updateProposalStages.ts
@@ -73,7 +73,8 @@ export async function updateProposalStages(
       //  4. Check if proposal should be marked as Executed or Rejected (off-chain only stages)
       //  After execution, the Governance contract zeroes all proposal data, causing
       //  getProposalStage() to return Expiration (5) for executed proposals.
-      //  We must check for a ProposalExecuted event before concluding it expired.
+      //  We must distinguish a just-executed proposal from a genuinely expired one
+      //  before concluding it expired.
       if (onChainStage === ProposalStage.Expiration) {
         const [executedEvent] = await database
           .select({ id: eventsTable.transactionHash })
@@ -88,23 +89,40 @@ export async function updateProposalStages(
           .limit(1);
 
         if (executedEvent) {
+          // A ProposalExecuted event is ground truth.
           onChainStage = ProposalStage.Executed;
           console.log(`  → Marking as Executed (found ProposalExecuted event)`);
         } else {
-          // Lazy-load votes only when we encounter a truly expired proposal
+          // No event yet. The ProposalExecuted event is ingested into eventsTable
+          // by the hourly backfill cron, while this stage cron runs every 5 minutes.
+          // In the gap between a successful execution and the next backfill, the
+          // event row is absent, so relying on it alone leaves a just-executed
+          // proposal shown as "Expired" for up to ~1 hour.
+          //
+          // Resolve it from votes + on-chain data instead:
+          //  - No > Yes  → Rejected. A proposal that lost can never have been
+          //    executed, so this check must come first (and guards against
+          //    misreading a zeroed slot as Executed).
+          //  - Otherwise, if the contract data is zeroed (proposer == 0x0) the
+          //    proposal was executed and deleted; a genuinely expired-but-
+          //    unexecuted proposal keeps its data (nobody bothers to execute it
+          //    once the window passes).
+          //  - Otherwise it is genuinely expired.
           if (!allVotes) {
             console.log('Found expired proposal, loading votes for Rejected calculation...');
             allVotes = await getProposalVotes(client.chain.id);
           }
 
           const votes = allVotes[proposal.id];
-          if (votes) {
-            const yesVotes = votes[VoteType.Yes] || 0n;
-            const noVotes = votes[VoteType.No] || 0n;
-            if (noVotes > yesVotes) {
-              onChainStage = ProposalStage.Rejected;
-              console.log(`  → Marking as Rejected (No: ${noVotes}, Yes: ${yesVotes})`);
-            }
+          const yesVotes = votes?.[VoteType.Yes] || 0n;
+          const noVotes = votes?.[VoteType.No] || 0n;
+
+          if (noVotes > yesVotes) {
+            onChainStage = ProposalStage.Rejected;
+            console.log(`  → Marking as Rejected (No: ${noVotes}, Yes: ${yesVotes})`);
+          } else if (await wasProposalExecutedOnChain(currentClient, proposal.id)) {
+            onChainStage = ProposalStage.Executed;
+            console.log(`  → Marking as Executed (proposal data zeroed on-chain)`);
           }
         }
       }
@@ -163,6 +181,36 @@ export async function updateProposalStages(
     console.log('✅ Stage updates complete');
   } else {
     console.log('No stage changes detected');
+  }
+}
+
+/**
+ * Determines whether a proposal that currently reports `Expiration` on-chain was
+ * actually executed (and thus deleted) rather than genuinely expired.
+ *
+ * The Governance contract zeroes a proposal's data on execution, so `getProposal`
+ * returns a zero-address proposer for executed proposals. A genuinely expired but
+ * unexecuted proposal keeps its original proposer. Returns false (treat as expired)
+ * if the read fails, so callers fall back to the existing vote-based logic.
+ */
+async function wasProposalExecutedOnChain(
+  client: PublicClient<Transport, Chain>,
+  proposalId: number,
+): Promise<boolean> {
+  try {
+    const [proposer] = (await client.readContract({
+      abi: governanceABI,
+      address: Addresses.Governance,
+      functionName: 'getProposal',
+      args: [BigInt(proposalId)],
+    })) as readonly [`0x${string}`, ...unknown[]];
+    return /^0x0+$/.test(proposer);
+  } catch (error) {
+    console.warn(
+      `  ⚠️ Could not read on-chain proposal data for ${proposalId}, treating as not-executed:`,
+      error,
+    );
+    return false;
   }
 }
 


### PR DESCRIPTION
## Problem

Just-executed governance proposals can display the **"Expired"** badge for up to ~1 hour before self-correcting. Observed on **CGP 239 / #295** ("Expand stCELO DefaultStrategy…"): passed 99.6% Yes, executed, yet showed *Expired Just now*, then fixed itself later.

## Root cause — race between two crons

| Cron | Cadence | Role |
|------|---------|------|
| `update-proposal-stages.yml` | every **5 min** | reads on-chain stage |
| `cronjob.yml` → `backfill-db` | every **1 hour** | ingests `ProposalExecuted` into `eventsTable` |

On execution the Governance contract **zeroes proposal data**, so `getProposalStage()` returns `Expiration(5)`. The stage cron distinguished executed-vs-expired **only** via a `ProposalExecuted` row in `eventsTable` — which the *hourly* backfill populates. In the gap, the event row is absent, the proposal is passing (Yes > No, so not Rejected), and it falls through to `Expiration`. Every 5-min run in that window flips the DB `Execution → Expiration`. The next hourly backfill ingests the event → next stage-cron run self-heals → `Executed`. = "fixed itself."

The MultiBaas webhook (`/api/webhooks/multibaas`) is the intended real-time path and normally sets `Executed` in seconds via `updateProposalsInDB`; for #295 it evidently missed/failed, so recovery fell back to the slow hourly path. **This PR hardens the fallback** (webhook reliability is a separate follow-up).

## Fix

When stage reads `Expiration` and no event is ingested yet, fall back to an on-chain check:

- **No > Yes → Rejected** (checked first — a losing proposal can never have been executed; also guards against a reused/zeroed dequeue slot being misread as Executed).
- Else, read `getProposal()`: executed proposals are **deleted** (proposer `0x0`); a genuinely expired-but-unexecuted proposal **keeps its data**. Zeroed proposer ⇒ **Executed**.
- Else ⇒ genuinely `Expiration`.

No dependency on the hourly backfill. A `ProposalExecuted` event remains ground truth when present.

## Verification

- On-chain (forno) for #295: `getProposalStage = 5`, `getProposal` proposer = `0x0000…0000` — confirms the discriminator.
- Shrinks the bad window from **~1h → ≤5min** regardless of webhook/backfill latency.
- `updateProposalStages.test.ts`: **14 tests pass**, incl. new cases:
  - on-chain self-heal `Execution → Executed` when data zeroed but event not yet ingested
  - safety guard: `No > Yes` ⇒ `Rejected` even when slot is zeroed (no false-positive Executed)
- ESLint + Prettier clean.

## Test plan

- [ ] Deploy; on next execution confirm proposal shows `Executed` within one 5-min cron tick (not ~1h)
- [ ] Follow-up: investigate why the MultiBaas webhook missed `ProposalExecuted` for #295 (subscription coverage / silent 403 reject path)