### PR TITLE
feat(webhooks): record event ingestion provenance (ingestedAt + ingestedVia)

### DIFF
--- a/drizzle/0007_event_ingestion_provenance.sql
+++ b/drizzle/0007_event_ingestion_provenance.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "events" ADD COLUMN "ingestedAt" timestamp with time zone DEFAULT now();--> statement-breakpoint
+ALTER TABLE "events" ADD COLUMN "ingestedVia" jsonb;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,760 @@
+{
+  "id": "62e0d64b-9476-4a27-a195-c2d388acdb15",
+  "prevId": "a878d5e2-4984-445a-be4f-83882f72c3b3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analyticsEvents": {
+      "name": "analyticsEvents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "eventName": {
+          "name": "eventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_analytics_events_name_properties": {
+          "name": "idx_analytics_events_name_properties",
+          "columns": [
+            {
+              "expression": "properties",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_analytics_events_name": {
+          "name": "idx_analytics_events_name",
+          "columns": [
+            {
+              "expression": "eventName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_analytics_events_created_at": {
+          "name": "idx_analytics_events_created_at",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approvals": {
+      "name": "approvals",
+      "schema": "",
+      "columns": {
+        "chainId": {
+          "name": "chainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposalId": {
+          "name": "proposalId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multisigTxId": {
+          "name": "multisigTxId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approver": {
+          "name": "approver",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmedAt": {
+          "name": "confirmedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockNumber": {
+          "name": "blockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transactionHash": {
+          "name": "transactionHash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "approvals_proposalId_index": {
+          "name": "approvals_proposalId_index",
+          "columns": [
+            {
+              "expression": "proposalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approvals_multisigTxId_index": {
+          "name": "approvals_multisigTxId_index",
+          "columns": [
+            {
+              "expression": "multisigTxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approvals_chainId_index": {
+          "name": "approvals_chainId_index",
+          "columns": [
+            {
+              "expression": "chainId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approvals_chainId_chains_id_fk": {
+          "name": "approvals_chainId_chains_id_fk",
+          "tableFrom": "approvals",
+          "tableTo": "chains",
+          "columnsFrom": [
+            "chainId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "approvals_proposalId_chainId_proposals_id_chainId_fk": {
+          "name": "approvals_proposalId_chainId_proposals_id_chainId_fk",
+          "tableFrom": "approvals",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposalId",
+            "chainId"
+          ],
+          "columnsTo": [
+            "id",
+            "chainId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "approvals_chainId_proposalId_approver_pk": {
+          "name": "approvals_chainId_proposalId_approver_pk",
+          "columns": [
+            "chainId",
+            "proposalId",
+            "approver"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocksProcessed": {
+      "name": "blocksProcessed",
+      "schema": "",
+      "columns": {
+        "chainId": {
+          "name": "chainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventName": {
+          "name": "eventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockNumber": {
+          "name": "blockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocksProcessed_chainId_chains_id_fk": {
+          "name": "blocksProcessed_chainId_chains_id_fk",
+          "tableFrom": "blocksProcessed",
+          "tableTo": "chains",
+          "columnsFrom": [
+            "chainId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blocksProcessed_eventName_chainId_pk": {
+          "name": "blocksProcessed_eventName_chainId_pk",
+          "columns": [
+            "eventName",
+            "chainId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chains": {
+      "name": "chains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "chainId": {
+          "name": "chainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventName": {
+          "name": "eventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args": {
+          "name": "args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockNumber": {
+          "name": "blockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transactionHash": {
+          "name": "transactionHash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingestedAt": {
+          "name": "ingestedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "ingestedVia": {
+          "name": "ingestedVia",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "events_blockNumber_index": {
+          "name": "events_blockNumber_index",
+          "columns": [
+            {
+              "expression": "blockNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_eventName_index": {
+          "name": "events_eventName_index",
+          "columns": [
+            {
+              "expression": "eventName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_chainId_index": {
+          "name": "events_chainId_index",
+          "columns": [
+            {
+              "expression": "chainId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_topics_proposalId_index": {
+          "name": "events_topics_proposalId_index",
+          "columns": [
+            {
+              "expression": "\"topics\"[2]",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_chainId_chains_id_fk": {
+          "name": "events_chainId_chains_id_fk",
+          "tableFrom": "events",
+          "tableTo": "chains",
+          "columnsFrom": [
+            "chainId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "events_eventName_transactionHash_chainId_pk": {
+          "name": "events_eventName_transactionHash_chainId_pk",
+          "columns": [
+            "eventName",
+            "transactionHash",
+            "chainId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "chainId": {
+          "name": "chainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pastId": {
+          "name": "pastId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cgp": {
+          "name": "cgp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cgpUrl": {
+          "name": "cgpUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cgpUrlRaw": {
+          "name": "cgpUrlRaw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposer": {
+          "name": "proposer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deposit": {
+          "name": "deposit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkWeight": {
+          "name": "networkWeight",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transactionCount": {
+          "name": "transactionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queuedAt": {
+          "name": "queuedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queuedAtBlockNumber": {
+          "name": "queuedAtBlockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dequeuedAt": {
+          "name": "dequeuedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dequeuedAtBlockNumber": {
+          "name": "dequeuedAtBlockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approvedAt": {
+          "name": "approvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approvedAtBlockNumber": {
+          "name": "approvedAtBlockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executedAt": {
+          "name": "executedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executedAtBlockNumber": {
+          "name": "executedAtBlockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorumVotesRequired": {
+          "name": "quorumVotesRequired",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "constitutionThreshold": {
+          "name": "constitutionThreshold",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposals_chainId_chains_id_fk": {
+          "name": "proposals_chainId_chains_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "chains",
+          "columnsFrom": [
+            "chainId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "proposals_pastId_chainId_proposals_id_chainId_fk": {
+          "name": "proposals_pastId_chainId_proposals_id_chainId_fk",
+          "tableFrom": "proposals",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "pastId",
+            "chainId"
+          ],
+          "columnsTo": [
+            "id",
+            "chainId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposals_id_chainId_pk": {
+          "name": "proposals_id_chainId_pk",
+          "columns": [
+            "id",
+            "chainId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "chainId": {
+          "name": "chainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "voteType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposalId": {
+          "name": "proposalId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_proposalId_chainId_proposals_id_chainId_fk": {
+          "name": "votes_proposalId_chainId_proposals_id_chainId_fk",
+          "tableFrom": "votes",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposalId",
+            "chainId"
+          ],
+          "columnsTo": [
+            "id",
+            "chainId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "votes_chainId_type_proposalId_pk": {
+          "name": "votes_chainId_type_proposalId_pk",
+          "columns": [
+            "chainId",
+            "type",
+            "proposalId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.voteType": {
+      "name": "voteType",
+      "schema": "public",
+      "values": [
+        "abstain",
+        "no",
+        "none",
+        "yes"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1774445502129,
       "tag": "0006_green_strong_guy",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1781681125157,
+      "tag": "0007_event_ingestion_provenance",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/webhooks/alchemy/route.test.ts
+++ b/src/app/api/webhooks/alchemy/route.test.ts
@@ -223,6 +223,7 @@ describe('POST /api/webhooks/alchemy', () => {
       expect(mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
         'Confirmation',
         expect.objectContaining({ chain: { id: 42220 } }),
+        { source: 'alchemy' },
       );
       expect(mockUpdateApprovalsInDB).toHaveBeenCalledTimes(1);
 
@@ -301,6 +302,7 @@ describe('POST /api/webhooks/alchemy', () => {
       expect(mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
         'Revocation',
         expect.anything(),
+        { source: 'alchemy' },
       );
       expect(mockUpdateApprovalsInDB).toHaveBeenCalled();
     });
@@ -346,6 +348,8 @@ describe('POST /api/webhooks/alchemy', () => {
       expect(mockFetchHistoricalEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
         'ProposalQueued',
         expect.anything(),
+        undefined,
+        'alchemy',
       );
       expect(mockUpdateProposalsInDB).toHaveBeenCalledWith(expect.anything(), [278n], 'update');
     });

--- a/src/app/api/webhooks/alchemy/route.ts
+++ b/src/app/api/webhooks/alchemy/route.ts
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest): Promise<Response> {
       return new Response(null, { status: 200 });
     }
 
-    await processWebhookEvents(parsedEvents);
+    await processWebhookEvents(parsedEvents, 'alchemy');
     return new Response(null, { status: 200 });
   } catch (err) {
     const error = err as Error;

--- a/src/app/api/webhooks/multibaas/route.test.ts
+++ b/src/app/api/webhooks/multibaas/route.test.ts
@@ -212,6 +212,7 @@ describe('POST /api/webhooks/multibaas', () => {
       expect(mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
         'Confirmation',
         expect.objectContaining({ chain: { id: 42220 } }),
+        { source: 'multibaas' },
       );
       expect(mockUpdateApprovalsInDB).toHaveBeenCalledTimes(1);
 
@@ -287,6 +288,7 @@ describe('POST /api/webhooks/multibaas', () => {
       expect(mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
         'Revocation',
         expect.anything(),
+        { source: 'multibaas' },
       );
       expect(mockUpdateApprovalsInDB).toHaveBeenCalled();
     });
@@ -335,6 +337,8 @@ describe('POST /api/webhooks/multibaas', () => {
       expect(mockFetchHistoricalEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
         'ProposalQueued',
         expect.anything(),
+        undefined,
+        'multibaas',
       );
       expect(mockUpdateProposalsInDB).toHaveBeenCalledWith(expect.anything(), [278n], 'update');
     });

--- a/src/app/api/webhooks/multibaas/route.ts
+++ b/src/app/api/webhooks/multibaas/route.ts
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest): Promise<Response> {
       return new Response(null, { status: 200 });
     }
 
-    await processWebhookEvents(parsedEvents);
+    await processWebhookEvents(parsedEvents, 'multibaas');
     return new Response(null, { status: 200 });
   } catch (err) {
     const error = err as Error;

--- a/src/app/api/webhooks/processWebhookEvents.ts
+++ b/src/app/api/webhooks/processWebhookEvents.ts
@@ -10,6 +10,7 @@ import fetchHistoricalEventsAndSaveToDBProgressively from 'src/features/governan
 import fetchHistoricalMultiSigEventsAndSaveToDBProgressively from 'src/features/governance/fetchHistoricalMultiSigEventsAndSaveToDBProgressively';
 import updateApprovalsInDB from 'src/features/governance/updateApprovalsInDB';
 import updateProposalsInDB from 'src/features/governance/updateProposalsInDB';
+import { IngestSource } from 'src/features/governance/utils/events/ingest';
 import { decodeAndPrepareProposalEvent } from 'src/features/governance/utils/events/proposal';
 import { decodeAndPrepareVoteEvent } from 'src/features/governance/utils/events/vote';
 import { celoPublicClient } from 'src/utils/client';
@@ -35,7 +36,10 @@ export type ParsedEvent = {
   transactionIds: bigint[];
 };
 
-export async function processWebhookEvents(parsedEvents: ParsedEvent[]): Promise<void> {
+export async function processWebhookEvents(
+  parsedEvents: ParsedEvent[],
+  source: IngestSource,
+): Promise<void> {
   let proposalId: bigint | undefined | null;
   const proposalIdsToUpdate: Set<bigint> = new Set();
   const multisigTxIdsToProcess: Set<bigint> = new Set();
@@ -61,6 +65,7 @@ export async function processWebhookEvents(parsedEvents: ParsedEvent[]): Promise
       const backfillResult = await fetchHistoricalMultiSigEventsAndSaveToDBProgressively(
         event.name,
         celoPublicClient,
+        { source },
       );
 
       for (const txId of backfillResult.transactionIds) {
@@ -77,6 +82,8 @@ export async function processWebhookEvents(parsedEvents: ParsedEvent[]): Promise
       const backfillProposalIds = await fetchHistoricalEventsAndSaveToDBProgressively(
         event.name,
         celoPublicClient,
+        undefined,
+        source,
       );
       for (const id of backfillProposalIds) {
         proposalIdsToUpdate.add(id);

--- a/src/app/governance/events.ts
+++ b/src/app/governance/events.ts
@@ -19,7 +19,12 @@ type EventName =
   | 'ProposalUpvoteRevoked'
   | 'ProposalExpired';
 
-export type Event = Awaited<ReturnType<typeof fetchProposalEvents>>[number];
+// Ingestion metadata (ingestedAt/ingestedVia) is write-time provenance, not part
+// of the decoded log that consumers read, so it is excluded from the Event shape.
+export type Event = Omit<
+  Awaited<ReturnType<typeof fetchProposalEvents>>[number],
+  'ingestedAt' | 'ingestedVia'
+>;
 
 export async function fetchProposalEvents(
   chainId: number,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -39,6 +39,12 @@ export const eventsTable = pgTable(
     data: text().notNull().$type<`0x${string}`>(),
     blockNumber: numeric({ mode: 'bigint' }).notNull(),
     transactionHash: varchar({ length: 66 }).notNull(),
+    // First time this row was ingested (set on insert, never overwritten on conflict).
+    ingestedAt: timestamp({ withTimezone: true }).defaultNow(),
+    // Per-provider first-arrival timestamps, e.g.
+    // { alchemy: "2026-06-12T12:15:31.000Z", multibaas: "2026-06-12T12:17:40.000Z" }.
+    // Accumulates providers on conflict; keeps the first timestamp seen per provider.
+    ingestedVia: jsonb().$type<Partial<Record<'alchemy' | 'multibaas' | 'cron', string>>>(),
   },
   (table) => [
     foreignKey({ columns: [table.chainId], foreignColumns: [chainsTable.id] }).onDelete('restrict'),

--- a/src/features/governance/fetchHistoricalEventsAndSaveToDBProgressively.ts
+++ b/src/features/governance/fetchHistoricalEventsAndSaveToDBProgressively.ts
@@ -5,6 +5,11 @@ import { resolveAddress } from '@celo/actions';
 import { sql } from 'drizzle-orm';
 import database from 'src/config/database';
 import { blocksProcessedTable, eventsTable } from 'src/db/schema';
+import {
+  IngestSource,
+  ingestedViaConflictSet,
+  withIngestionMetadata,
+} from 'src/features/governance/utils/events/ingest';
 import { assertEvent } from 'src/features/governance/utils/votes';
 import {
   Chain,
@@ -41,6 +46,7 @@ export default async function fetchHistoricalEventsAndSaveToDBProgressively(
   eventName: string,
   client: PublicClient<Transport, Chain>,
   fromBlock?: bigint,
+  source: IngestSource = 'cron',
 ): Promise<bigint[]> {
   if (!assertEvent(VALID_EVENTS, eventName)) {
     console.info('Not a valid event', eventName);
@@ -93,8 +99,11 @@ export default async function fetchHistoricalEventsAndSaveToDBProgressively(
         );
         const { count } = await database
           .insert(eventsTable)
-          .values(events.map((event) => ({ ...event, chainId: client.chain.id })))
-          .onConflictDoNothing();
+          .values(withIngestionMetadata(events, client.chain.id, source))
+          .onConflictDoUpdate({
+            target: [eventsTable.eventName, eventsTable.transactionHash, eventsTable.chainId],
+            set: ingestedViaConflictSet,
+          });
         console.log({ inserts: count });
       }
     } catch (e) {

--- a/src/features/governance/fetchHistoricalMultiSigEventsAndSaveToDBProgressively.ts
+++ b/src/features/governance/fetchHistoricalMultiSigEventsAndSaveToDBProgressively.ts
@@ -5,6 +5,11 @@ import { sql } from 'drizzle-orm';
 import { Addresses } from 'src/config/contracts';
 import database from 'src/config/database';
 import { blocksProcessedTable, eventsTable } from 'src/db/schema';
+import {
+  IngestSource,
+  ingestedViaConflictSet,
+  withIngestionMetadata,
+} from 'src/features/governance/utils/events/ingest';
 import { assertEvent } from 'src/features/governance/utils/votes';
 import { sleep } from 'src/utils/async';
 import {
@@ -35,6 +40,7 @@ export interface FetchMultiSigEventsOptions {
   targetConfirmations?: number;
   searchDirection?: 'forward' | 'backward';
   saveProgress?: boolean;
+  source?: IngestSource;
 }
 
 export interface FetchMultiSigEventsResult {
@@ -64,6 +70,7 @@ export default async function fetchHistoricalMultiSigEventsAndSaveToDBProgressiv
     targetConfirmations,
     searchDirection = 'forward',
     saveProgress = true,
+    source = 'cron',
   } = options;
 
   if (!assertEvent(VALID_MULTISIG_EVENTS, eventName)) {
@@ -205,8 +212,15 @@ export default async function fetchHistoricalMultiSigEventsAndSaveToDBProgressiv
               try {
                 await database
                   .insert(eventsTable)
-                  .values(events.map((event) => ({ ...event, chainId: client.chain.id })))
-                  .onConflictDoNothing();
+                  .values(withIngestionMetadata(events, client.chain.id, source))
+                  .onConflictDoUpdate({
+                    target: [
+                      eventsTable.eventName,
+                      eventsTable.transactionHash,
+                      eventsTable.chainId,
+                    ],
+                    set: ingestedViaConflictSet,
+                  });
                 saved = true;
               } catch (dbError: any) {
                 saveRetries--;
@@ -237,8 +251,11 @@ export default async function fetchHistoricalMultiSigEventsAndSaveToDBProgressiv
           try {
             const { count } = await database
               .insert(eventsTable)
-              .values(events.map((event) => ({ ...event, chainId: client.chain.id })))
-              .onConflictDoNothing();
+              .values(withIngestionMetadata(events, client.chain.id, source))
+              .onConflictDoUpdate({
+                target: [eventsTable.eventName, eventsTable.transactionHash, eventsTable.chainId],
+                set: ingestedViaConflictSet,
+              });
             console.log({ inserts: count });
             inserted = true;
           } catch (dbError: any) {

--- a/src/features/governance/utils/events/ingest.test.ts
+++ b/src/features/governance/utils/events/ingest.test.ts
@@ -1,0 +1,97 @@
+import { and, eq } from 'drizzle-orm';
+import database from 'src/config/database';
+import { eventsTable } from 'src/db/schema';
+import { TEST_CHAIN_ID } from 'src/test/database';
+import { describe, expect, it } from 'vitest';
+
+import { ingestedViaConflictSet, IngestSource, withIngestionMetadata } from './ingest';
+
+const PK = {
+  eventName: 'ProposalExecuted' as const,
+  transactionHash: '0x63b59de749a858b7ca0973357a651e9d893eb1d22b585b5c01d7dae2ae3c95aa',
+};
+
+function baseEvent() {
+  return {
+    ...PK,
+    args: { proposalId: '295' },
+    address: '0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972',
+    topics: ['0x712ae1383f79ac853f8d882153778e0260ef8f03b504e2866e0593e04d2b291f'] as [
+      `0x${string}`,
+      ...`0x${string}`[],
+    ],
+    data: '0x' as `0x${string}`,
+    blockNumber: 69399792n,
+  };
+}
+
+async function ingest(source: IngestSource) {
+  await database
+    .insert(eventsTable)
+    .values(withIngestionMetadata([baseEvent()], TEST_CHAIN_ID, source))
+    .onConflictDoUpdate({
+      target: [eventsTable.eventName, eventsTable.transactionHash, eventsTable.chainId],
+      set: ingestedViaConflictSet,
+    });
+}
+
+async function readRow() {
+  const [row] = await database
+    .select()
+    .from(eventsTable)
+    .where(
+      and(
+        eq(eventsTable.eventName, PK.eventName),
+        eq(eventsTable.transactionHash, PK.transactionHash),
+        eq(eventsTable.chainId, TEST_CHAIN_ID),
+      ),
+    );
+  return row;
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 5));
+
+describe('event ingestion provenance', () => {
+  it('records the provider and a timestamp on first insert', async () => {
+    await ingest('alchemy');
+    const row = await readRow();
+
+    expect(Object.keys(row.ingestedVia ?? {})).toEqual(['alchemy']);
+    expect(row.ingestedVia?.alchemy).toBeTruthy();
+    expect(row.ingestedAt).toBeTruthy();
+  });
+
+  it('accumulates a second provider without overwriting the first (one row, both providers)', async () => {
+    await ingest('alchemy');
+    const first = await readRow();
+    await tick();
+    await ingest('multibaas');
+    const row = await readRow();
+
+    // still a single row (PK dedup)
+    const all = await database.select().from(eventsTable);
+    expect(all).toHaveLength(1);
+
+    // both providers present, alchemy timestamp unchanged, ingestedAt unchanged
+    expect(Object.keys(row.ingestedVia ?? {}).sort()).toEqual(['alchemy', 'multibaas']);
+    expect(row.ingestedVia?.alchemy).toBe(first.ingestedVia?.alchemy);
+    expect(row.ingestedVia?.multibaas).toBeTruthy();
+    expect(row.ingestedAt).toEqual(first.ingestedAt);
+  });
+
+  it('keeps the first arrival timestamp when the same provider re-delivers', async () => {
+    await ingest('alchemy');
+    const first = await readRow();
+    await tick();
+    await ingest('alchemy');
+    const row = await readRow();
+
+    expect(row.ingestedVia?.alchemy).toBe(first.ingestedVia?.alchemy);
+  });
+
+  it('cron-sourced ingestion is recorded too', async () => {
+    await ingest('cron');
+    const row = await readRow();
+    expect(Object.keys(row.ingestedVia ?? {})).toEqual(['cron']);
+  });
+});

--- a/src/features/governance/utils/events/ingest.test.ts
+++ b/src/features/governance/utils/events/ingest.test.ts
@@ -4,7 +4,12 @@ import { eventsTable } from 'src/db/schema';
 import { TEST_CHAIN_ID } from 'src/test/database';
 import { describe, expect, it } from 'vitest';
 
-import { ingestedViaConflictSet, IngestSource, withIngestionMetadata } from './ingest';
+import {
+  formatIngestedVia,
+  ingestedViaConflictSet,
+  IngestSource,
+  withIngestionMetadata,
+} from './ingest';
 
 const PK = {
   eventName: 'ProposalExecuted' as const,
@@ -93,5 +98,40 @@ describe('event ingestion provenance', () => {
     await ingest('cron');
     const row = await readRow();
     expect(Object.keys(row.ingestedVia ?? {})).toEqual(['cron']);
+  });
+
+  it('same event received via Alchemy then MultiBaas → one row recording both providers', async () => {
+    // Simulates the same on-chain ProposalExecuted delivered by both webhooks:
+    // the Alchemy backfill writes it first, then the MultiBaas backfill writes
+    // the identical event (same PK). End state must be a single row whose
+    // ingestedVia records both providers, each with its own first-arrival time.
+    await ingest('alchemy');
+    const afterAlchemy = await readRow();
+    await tick();
+    await ingest('multibaas');
+
+    const all = await database.select().from(eventsTable);
+    expect(all).toHaveLength(1);
+
+    const row = all[0];
+    expect(row.ingestedVia).toEqual({
+      alchemy: afterAlchemy.ingestedVia?.alchemy,
+      multibaas: expect.any(String),
+    });
+    // alchemy arrived first, so it must sort first in the rendered string
+    expect(formatIngestedVia(row.ingestedVia)).toMatch(
+      /^alchemy \(\d\d:\d\d:\d\d\), multibaas \(\d\d:\d\d:\d\d\)$/,
+    );
+  });
+
+  it('order of arrival is reflected: MultiBaas first, then Alchemy', async () => {
+    await ingest('multibaas');
+    await tick();
+    await ingest('alchemy');
+
+    const row = await readRow();
+    expect(Object.keys(row.ingestedVia ?? {}).sort()).toEqual(['alchemy', 'multibaas']);
+    // multibaas arrived first → renders first
+    expect(formatIngestedVia(row.ingestedVia)).toMatch(/^multibaas \(.*\), alchemy \(.*\)$/);
   });
 });

--- a/src/features/governance/utils/events/ingest.ts
+++ b/src/features/governance/utils/events/ingest.ts
@@ -1,0 +1,37 @@
+import { sql } from 'drizzle-orm';
+import { eventsTable } from 'src/db/schema';
+
+/**
+ * Where an event row was ingested from. Webhook providers deliver in real time;
+ * `cron` is the periodic backfill that scans the chain on a schedule.
+ */
+export type IngestSource = 'alchemy' | 'multibaas' | 'cron';
+
+type WithChainAndIngestion<T> = T & {
+  chainId: number;
+  ingestedVia: Partial<Record<IngestSource, string>>;
+};
+
+/**
+ * Stamps a batch of decoded events with their chainId and a per-provider
+ * ingestion timestamp ({ [source]: ISO }) so the insert can record provenance.
+ */
+export function withIngestionMetadata<T extends object>(
+  events: T[],
+  chainId: number,
+  source: IngestSource,
+): WithChainAndIngestion<T>[] {
+  const at = new Date().toISOString();
+  return events.map((event) => ({ ...event, chainId, ingestedVia: { [source]: at } }));
+}
+
+/**
+ * `onConflictDoUpdate({ set })` clause that accumulates providers without losing
+ * the first arrival per provider. jsonb `a || b` is right-biased on key
+ * collision, so `excluded || existing` keeps the existing (earliest) timestamp
+ * for a provider already present while still adding any new provider keys.
+ * `ingestedAt` is intentionally not updated, preserving first-seen time.
+ */
+export const ingestedViaConflictSet = {
+  ingestedVia: sql`excluded."ingestedVia" || coalesce(${eventsTable.ingestedVia}, '{}'::jsonb)`,
+};

--- a/src/features/governance/utils/events/ingest.ts
+++ b/src/features/governance/utils/events/ingest.ts
@@ -35,3 +35,17 @@ export function withIngestionMetadata<T extends object>(
 export const ingestedViaConflictSet = {
   ingestedVia: sql`excluded."ingestedVia" || coalesce(${eventsTable.ingestedVia}, '{}'::jsonb)`,
 };
+
+/**
+ * Renders an ingestedVia map for display, ordered by arrival time, e.g.
+ * `alchemy (12:15:31), multibaas (12:17:40)`.
+ */
+export function formatIngestedVia(
+  ingestedVia: Partial<Record<IngestSource, string>> | null | undefined,
+): string {
+  if (!ingestedVia) return '';
+  return Object.entries(ingestedVia)
+    .sort(([, a], [, b]) => a.localeCompare(b))
+    .map(([source, iso]) => `${source} (${iso.slice(11, 19)})`)
+    .join(', ');
+}


### PR DESCRIPTION
Stacked on **#479**. Base = `shazarre/chore/alchemy_webhook_endpoint` (retarget to `main` if #479 merges first).

## Why

After #479 we have two webhook providers (+ the hourly cron) all writing the same `events` table — but no way to tell **who delivered an event, or when**. That's exactly the blind spot behind the CGP-239/#295 "Expired" incident: we couldn't prove from the DB whether the webhook fired in real time or the hourly backfill caught it.

## What

**Schema (additive, nullable — no backfill, safe migration `0007`):**
- `events.ingestedAt` — `timestamptz default now()`, first-seen time (never overwritten).
- `events.ingestedVia` — `jsonb` map of per-provider first-arrival timestamps:
  ```json
  { "alchemy": "2026-06-12T12:15:31.000Z", "multibaas": "2026-06-12T12:17:40.000Z" }
  ```
  Renders to your `alchemy (12:15:31), multibaas (12:17:40)`.

**Threading:**
- New `IngestSource` (`'alchemy' | 'multibaas' | 'cron'`) flows from each webhook route → `processWebhookEvents` → both backfill functions. Script/cron callers default to `'cron'`.
- Inserts switch `onConflictDoNothing` → `onConflictDoUpdate` with a jsonb merge `excluded."ingestedVia" || coalesce(existing, '{}')`:
  - **accumulates** new providers (one event delivered by both → both recorded),
  - **keep-first** per provider (re-delivery doesn't move the timestamp),
  - leaves `ingestedAt` untouched.
- Shared helper `utils/events/ingest.ts` (`withIngestionMetadata` + `ingestedViaConflictSet`).
- `Event` type excludes the new columns — they're write-time provenance, not part of the decoded log consumers read.

## Why accumulate (not first/last-writer)

You asked for the full picture rather than a single value. A single column (first- or last-writer) can't show "arrived via both." The jsonb map records each provider's first arrival independently, so you can see real-time webhook vs hourly cron at a glance — and diagnose the next #295 directly from the row.

One honest caveat: the backfill scans a *range* and bulk-inserts every event in it, so a webhook triggered by event X also first-stamps sibling events in the same gap with its provider. Accurate (that scan did first-ingest them), just coarser than per-event delivery.

## Tests

- New `ingest.test.ts` runs the **real merge SQL against PGlite**: first insert; two-provider accumulation (single row, first timestamps preserved, `ingestedAt` stable); same-provider re-delivery keep-first; cron source.
- Webhook route tests updated to assert the `source` arg.
- Full governance + scripts suites: **109 passed**. Typecheck clean (only pre-existing posthog module-resolution noise).

## Test plan
- [ ] After cutover, inspect a freshly-executed proposal's `ProposalExecuted` row: `ingestedVia` should show `alchemy` with a timestamp ~seconds after the block (proves real-time delivery); a `cron`-only value means the webhook missed.