### PR TITLE
fix(webhooks): run event backfill on archive node, not rate-limited forno

### DIFF
--- a/src/app/api/webhooks/alchemy/route.test.ts
+++ b/src/app/api/webhooks/alchemy/route.test.ts
@@ -58,12 +58,13 @@ vi.mock('src/features/governance/utils/events/vote', () => ({
 }));
 
 const mockReadContract = vi.fn();
-vi.mock('src/utils/client', () => ({
-  celoPublicClient: {
+vi.mock('src/utils/client', () => {
+  const client = {
     chain: { id: 42220 },
     readContract: (...args: unknown[]) => mockReadContract(...args),
-  },
-}));
+  };
+  return { celoPublicClient: client, celoArchiveClient: client };
+});
 
 const mockSendAlertToSlack = vi.fn().mockResolvedValue(undefined);
 vi.mock('src/config/slackbot', () => ({

--- a/src/app/api/webhooks/multibaas/route.test.ts
+++ b/src/app/api/webhooks/multibaas/route.test.ts
@@ -58,12 +58,13 @@ vi.mock('src/features/governance/utils/events/vote', () => ({
 }));
 
 const mockReadContract = vi.fn();
-vi.mock('src/utils/client', () => ({
-  celoPublicClient: {
+vi.mock('src/utils/client', () => {
+  const client = {
     chain: { id: 42220 },
     readContract: (...args: unknown[]) => mockReadContract(...args),
-  },
-}));
+  };
+  return { celoPublicClient: client, celoArchiveClient: client };
+});
 
 const mockSendAlertToSlack = vi.fn().mockResolvedValue(undefined);
 vi.mock('src/config/slackbot', () => ({

--- a/src/app/api/webhooks/processWebhookEvents.ts
+++ b/src/app/api/webhooks/processWebhookEvents.ts
@@ -13,7 +13,7 @@ import updateProposalsInDB from 'src/features/governance/updateProposalsInDB';
 import { IngestSource } from 'src/features/governance/utils/events/ingest';
 import { decodeAndPrepareProposalEvent } from 'src/features/governance/utils/events/proposal';
 import { decodeAndPrepareVoteEvent } from 'src/features/governance/utils/events/vote';
-import { celoPublicClient } from 'src/utils/client';
+import { celoArchiveClient, celoPublicClient } from 'src/utils/client';
 import { GetContractEventsParameters } from 'viem';
 
 type GovernanceEventName = Exclude<
@@ -62,9 +62,11 @@ export async function processWebhookEvents(
       // Process MultiSig events - use backfill result to capture ALL new transactionIds,
       // not just the one from the webhook event. This prevents missed approvals when the
       // backfill advances progress past events that the webhook didn't specifically trigger for.
+      // Backfill scans event history via eth_getLogs over wide block ranges, which
+      // public forno rejects ("query exceeds range") — use the archive node.
       const backfillResult = await fetchHistoricalMultiSigEventsAndSaveToDBProgressively(
         event.name,
-        celoPublicClient,
+        celoArchiveClient,
         { source },
       );
 
@@ -79,9 +81,11 @@ export async function processWebhookEvents(
     } else {
       // Process Governance events - capture backfill proposalIds to ensure we update
       // proposals that the backfill discovered (not just the webhook event itself).
+      // Backfill scans event history via eth_getLogs over wide block ranges, which
+      // public forno rejects ("query exceeds range") — use the archive node.
       const backfillProposalIds = await fetchHistoricalEventsAndSaveToDBProgressively(
         event.name,
-        celoPublicClient,
+        celoArchiveClient,
         undefined,
         source,
       );

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -9,6 +9,26 @@ export const celoPublicClient = createPublicClient({
   },
 });
 
+/**
+ * Client backed by the non-rate-limited archive node, for heavy historical reads
+ * (e.g. eth_getLogs over wide block ranges). Public forno rejects such ranges with
+ * "query exceeds range, retry smaller", so any code that scans event history —
+ * notably the webhook backfill — must use this client, the same way the cron
+ * scripts do. Falls back to the forno-backed client on testnet or when the archive
+ * node env var is not set (e.g. local dev).
+ */
+const archiveNodeUrl = process.env.PRIVATE_NO_RATE_LIMITED_NODE;
+export const celoArchiveClient =
+  config.chain.testnet || !archiveNodeUrl
+    ? celoPublicClient
+    : createPublicClient({
+        chain: config.chain,
+        transport: http(archiveNodeUrl),
+        batch: {
+          multicall: true,
+        },
+      });
+
 export const createCeloWalletClient = (account: Account) =>
   createWalletClient({
     account,


### PR DESCRIPTION
## Problem (live in prod)

Both webhook providers were returning **500** on every delivery → no real-time ingestion; the DB stayed fresh only via the hourly cron (~1–2h lag). Captured from prod logs:

```
URL: https://forno.celo.org?apikey=...
eth_getLogs ... fromBlock 0x42958b9 toBlock 0x4295ed3
Details: {"code":-32602,"message":"query exceeds range, retry smaller"}
... Halved the block step down to 50000 / 25000 / ... / 1562
Error: Retried too many times now...   → 500
```

The webhook backfill (`fetchHistorical{,MultiSig}EventsAndSaveToDBProgressively`) scans event history via `eth_getLogs`, but it ran on **`celoPublicClient`, hardcoded to public forno** (`src/utils/client.ts`). Forno rejects wide `getLogs` ranges; the step-halving retry exhausts → `Retried too many times` → 500. The cron avoids this by using `PRIVATE_NO_RATE_LIMITED_NODE`; the webhook never did.

This is the real root cause of the CGP-239/#295 "Expired" lag — not a missed event, not the secret. (Setting an env var didn't help: `celoPublicClient` doesn't read any RPC env; it's hardcoded.)

## Fix

- Add **`celoArchiveClient`** in `src/utils/client.ts`, backed by `PRIVATE_NO_RATE_LIMITED_NODE` (same node the cron uses). Falls back to the forno client on testnet / when the env var is unset (local dev).
- Use it for the **two backfill `getLogs` scans** in `processWebhookEvents`.
- **Current-state reads stay on forno** (`approver`, `updateProposalsInDB`, `updateApprovalsInDB`) — they're `eth_call` only (verified: no `getLogs` in them), so they don't hit the range limit and avoid the archive node's occasional staleness.

## Tests
- Webhook route tests: client mock now exports `celoArchiveClient` (same mock client). **36 pass.** tsc + prettier clean.

## Verify after deploy
- Alchemy dashboard response-code chart: `500 → 200`.
- prod `events.ingestedVia` starts showing `alchemy` (and `multibaas`) within seconds of a governance event; cursor tracks head instead of the ~1–2h cron cadence.