### PR TITLE
refactor(webhooks): ingest delivered event directly, drop per-delivery chain scan

### DIFF
--- a/src/app/api/webhooks/alchemy/route.test.ts
+++ b/src/app/api/webhooks/alchemy/route.test.ts
@@ -200,13 +200,7 @@ describe('POST /api/webhooks/alchemy', () => {
   });
 
   describe('MultiSig event processing', () => {
-    it('collects transactionIds from backfill result and decoded args, passes them to updateApprovalsInDB', async () => {
-      const backfillTxIds = [100n, 101n];
-      mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively.mockResolvedValueOnce({
-        transactionIds: backfillTxIds,
-        confirmationCount: 2,
-        lastEventBlock: 59520678n,
-      });
+    it('collects transactionId from the delivered event and passes it to updateApprovalsInDB', async () => {
       mockDecodeEventLog.mockReturnValue({
         eventName: 'Confirmation',
         args: { sender: '0x1234', transactionId: 102n },
@@ -221,16 +215,10 @@ describe('POST /api/webhooks/alchemy', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
-        'Confirmation',
-        expect.objectContaining({ chain: { id: 42220 } }),
-        { source: 'alchemy' },
-      );
       expect(mockUpdateApprovalsInDB).toHaveBeenCalledTimes(1);
 
       const passedTxIds = mockUpdateApprovalsInDB.mock.calls[0][1] as bigint[];
-      expect(passedTxIds).toEqual(expect.arrayContaining([100n, 101n, 102n]));
-      expect(passedTxIds).toHaveLength(3);
+      expect(passedTxIds).toEqual([102n]);
     });
 
     it('deduplicates transactionIds from backfill and decoded args', async () => {
@@ -257,12 +245,7 @@ describe('POST /api/webhooks/alchemy', () => {
       expect(passedTxIds).toContainEqual(248n);
     });
 
-    it('handles backfill returning transactionIds even when log decoding fails', async () => {
-      mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively.mockResolvedValueOnce({
-        transactionIds: [200n, 201n],
-        confirmationCount: 2,
-        lastEventBlock: 59520678n,
-      });
+    it('skips approvals when the event cannot be decoded (no transactionId)', async () => {
       mockDecodeEventLog.mockImplementation(() => {
         throw new Error('decode failed');
       });
@@ -276,16 +259,10 @@ describe('POST /api/webhooks/alchemy', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      const passedTxIds = mockUpdateApprovalsInDB.mock.calls[0][1] as bigint[];
-      expect(passedTxIds).toEqual(expect.arrayContaining([200n, 201n]));
+      expect(mockUpdateApprovalsInDB).not.toHaveBeenCalled();
     });
 
     it('processes Revocation events through the same pipeline', async () => {
-      mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively.mockResolvedValueOnce({
-        transactionIds: [50n],
-        confirmationCount: 0,
-        lastEventBlock: 100n,
-      });
       mockDecodeEventLog.mockReturnValue({
         eventName: 'Revocation',
         args: { sender: '0x1234', transactionId: 50n },
@@ -300,12 +277,7 @@ describe('POST /api/webhooks/alchemy', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
-        'Revocation',
-        expect.anything(),
-        { source: 'alchemy' },
-      );
-      expect(mockUpdateApprovalsInDB).toHaveBeenCalled();
+      expect(mockUpdateApprovalsInDB).toHaveBeenCalledWith(expect.anything(), [50n]);
     });
 
     it('does not call updateApprovalsInDB when no multisig events are present', async () => {
@@ -346,31 +318,10 @@ describe('POST /api/webhooks/alchemy', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(mockFetchHistoricalEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
-        'ProposalQueued',
-        expect.anything(),
-        undefined,
-        'alchemy',
-      );
       expect(mockUpdateProposalsInDB).toHaveBeenCalledWith(expect.anything(), [278n], 'update');
     });
 
-    it('includes proposalIds from governance backfill in updateProposalsInDB call', async () => {
-      mockFetchHistoricalEventsAndSaveToDBProgressively.mockResolvedValueOnce([275n, 276n]);
-      mockDecodeAndPrepareProposalEvent.mockResolvedValueOnce(278n);
-
-      const log = makeAlchemyLog();
-      const request = createSignedRequest(makeAlchemyPayload([log]));
-      const response = await POST(request);
-
-      expect(response.status).toBe(200);
-      const passedProposalIds = mockUpdateProposalsInDB.mock.calls[0][1] as bigint[];
-      expect(passedProposalIds).toEqual(expect.arrayContaining([275n, 276n, 278n]));
-      expect(passedProposalIds).toHaveLength(3);
-    });
-
-    it('updates proposals from backfill even when webhook event decoding returns null', async () => {
-      mockFetchHistoricalEventsAndSaveToDBProgressively.mockResolvedValueOnce([275n]);
+    it('does not call updateProposalsInDB when the event decodes to neither proposal nor vote', async () => {
       mockDecodeAndPrepareProposalEvent.mockResolvedValueOnce(null);
       mockDecodeAndPrepareVoteEvent.mockResolvedValueOnce([]);
 
@@ -379,7 +330,7 @@ describe('POST /api/webhooks/alchemy', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(mockUpdateProposalsInDB).toHaveBeenCalledWith(expect.anything(), [275n], 'update');
+      expect(mockUpdateProposalsInDB).not.toHaveBeenCalled();
     });
 
     it('handles mixed governance and multisig events in a single webhook', async () => {
@@ -452,7 +403,6 @@ describe('POST /api/webhooks/alchemy', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(mockFetchHistoricalEventsAndSaveToDBProgressively).toHaveBeenCalled();
       expect(mockUpdateProposalsInDB).toHaveBeenCalled();
     });
 

--- a/src/app/api/webhooks/alchemy/route.ts
+++ b/src/app/api/webhooks/alchemy/route.ts
@@ -105,6 +105,8 @@ export async function POST(request: NextRequest): Promise<Response> {
         contractAddress: log.account.address,
         topics,
         data,
+        blockNumber: BigInt(block.number),
+        transactionHash: log.transaction.hash as `0x${string}`,
         transactionIds,
       });
     }

--- a/src/app/api/webhooks/multibaas/route.test.ts
+++ b/src/app/api/webhooks/multibaas/route.test.ts
@@ -185,14 +185,7 @@ describe('POST /api/webhooks/multibaas', () => {
   });
 
   describe('MultiSig event processing', () => {
-    it('collects transactionIds from backfill result and passes them to updateApprovalsInDB', async () => {
-      const backfillTxIds = [100n, 101n];
-      mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively.mockResolvedValueOnce({
-        transactionIds: backfillTxIds,
-        confirmationCount: 2,
-        lastEventBlock: 59520678n,
-      });
-
+    it('collects transactionIds from the delivered event (rawFields args + inputs)', async () => {
       const event = makeMultiBaasEvent({
         name: 'Confirmation',
         contractAddress: MOCK_APPROVER_MULTISIG,
@@ -206,17 +199,12 @@ describe('POST /api/webhooks/multibaas', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
-        'Confirmation',
-        expect.objectContaining({ chain: { id: 42220 } }),
-        { source: 'multibaas' },
-      );
       expect(mockUpdateApprovalsInDB).toHaveBeenCalledTimes(1);
 
-      // Should include backfill IDs (100, 101), rawFields ID (103), and inputs ID (102)
+      // rawFields args ID (103) and inputs ID (102), both from the payload
       const passedTxIds = mockUpdateApprovalsInDB.mock.calls[0][1] as bigint[];
-      expect(passedTxIds).toEqual(expect.arrayContaining([100n, 101n, 102n, 103n]));
-      expect(passedTxIds).toHaveLength(4);
+      expect(passedTxIds).toEqual(expect.arrayContaining([102n, 103n]));
+      expect(passedTxIds).toHaveLength(2);
     });
 
     it('deduplicates transactionIds from multiple sources', async () => {
@@ -243,13 +231,7 @@ describe('POST /api/webhooks/multibaas', () => {
       expect(passedTxIds).toContainEqual(248n);
     });
 
-    it('handles backfill returning transactionIds even when rawFields parsing fails', async () => {
-      mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively.mockResolvedValueOnce({
-        transactionIds: [200n, 201n],
-        confirmationCount: 2,
-        lastEventBlock: 59520678n,
-      });
-
+    it('skips approvals when rawFields is unparsable and no inputs provide a transactionId', async () => {
       const event = makeMultiBaasEvent({
         name: 'Confirmation',
         contractAddress: MOCK_APPROVER_MULTISIG,
@@ -261,17 +243,10 @@ describe('POST /api/webhooks/multibaas', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      const passedTxIds = mockUpdateApprovalsInDB.mock.calls[0][1] as bigint[];
-      expect(passedTxIds).toEqual(expect.arrayContaining([200n, 201n]));
+      expect(mockUpdateApprovalsInDB).not.toHaveBeenCalled();
     });
 
     it('processes Revocation events through the same pipeline', async () => {
-      mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively.mockResolvedValueOnce({
-        transactionIds: [50n],
-        confirmationCount: 0,
-        lastEventBlock: 100n,
-      });
-
       const event = makeMultiBaasEvent({
         name: 'Revocation',
         contractAddress: MOCK_APPROVER_MULTISIG,
@@ -282,12 +257,7 @@ describe('POST /api/webhooks/multibaas', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(mockFetchHistoricalMultiSigEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
-        'Revocation',
-        expect.anything(),
-        { source: 'multibaas' },
-      );
-      expect(mockUpdateApprovalsInDB).toHaveBeenCalled();
+      expect(mockUpdateApprovalsInDB).toHaveBeenCalledWith(expect.anything(), [50n]);
     });
 
     it('does not call updateApprovalsInDB when no multisig events are present', async () => {
@@ -331,39 +301,10 @@ describe('POST /api/webhooks/multibaas', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(mockFetchHistoricalEventsAndSaveToDBProgressively).toHaveBeenCalledWith(
-        'ProposalQueued',
-        expect.anything(),
-        undefined,
-        'multibaas',
-      );
       expect(mockUpdateProposalsInDB).toHaveBeenCalledWith(expect.anything(), [278n], 'update');
     });
 
-    it('includes proposalIds from governance backfill in updateProposalsInDB call', async () => {
-      // Backfill discovers proposals 275 and 276 that were missed
-      mockFetchHistoricalEventsAndSaveToDBProgressively.mockResolvedValueOnce([275n, 276n]);
-      // The webhook event itself is for proposal 278
-      mockDecodeAndPrepareProposalEvent.mockResolvedValueOnce(278n);
-
-      const event = makeMultiBaasEvent({
-        name: 'ProposalQueued',
-        rawFields: JSON.stringify({ topics: ['0x'], data: '0x' }),
-      });
-
-      const request = createSignedRequest([event]);
-      const response = await POST(request);
-
-      expect(response.status).toBe(200);
-      const passedProposalIds = mockUpdateProposalsInDB.mock.calls[0][1] as bigint[];
-      expect(passedProposalIds).toEqual(expect.arrayContaining([275n, 276n, 278n]));
-      expect(passedProposalIds).toHaveLength(3);
-    });
-
-    it('updates proposals from backfill even when webhook event decoding returns null', async () => {
-      // Backfill discovers proposal 275
-      mockFetchHistoricalEventsAndSaveToDBProgressively.mockResolvedValueOnce([275n]);
-      // The webhook event itself fails to decode (not a proposal event)
+    it('does not call updateProposalsInDB when the event decodes to neither proposal nor vote', async () => {
       mockDecodeAndPrepareProposalEvent.mockResolvedValueOnce(null);
       mockDecodeAndPrepareVoteEvent.mockResolvedValueOnce([]);
 
@@ -376,7 +317,7 @@ describe('POST /api/webhooks/multibaas', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(mockUpdateProposalsInDB).toHaveBeenCalledWith(expect.anything(), [275n], 'update');
+      expect(mockUpdateProposalsInDB).not.toHaveBeenCalled();
     });
 
     it('handles mixed governance and multisig events in a single webhook', async () => {
@@ -433,7 +374,6 @@ describe('POST /api/webhooks/multibaas', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(mockFetchHistoricalEventsAndSaveToDBProgressively).toHaveBeenCalled();
       expect(mockUpdateProposalsInDB).toHaveBeenCalled();
     });
 

--- a/src/app/api/webhooks/multibaas/route.ts
+++ b/src/app/api/webhooks/multibaas/route.ts
@@ -51,7 +51,13 @@ export async function POST(request: NextRequest): Promise<Response> {
     for (const {
       data: { event },
     } of body) {
-      let parsedFields: { topics?: unknown[]; data?: string; args?: Record<string, unknown> } = {};
+      let parsedFields: {
+        topics?: unknown[];
+        data?: string;
+        args?: Record<string, unknown>;
+        blockNumber?: string;
+        transactionHash?: string;
+      } = {};
       try {
         parsedFields = JSON.parse(event.rawFields);
       } catch {
@@ -75,6 +81,8 @@ export async function POST(request: NextRequest): Promise<Response> {
         contractAddress: event.contract.address,
         topics: (parsedFields.topics ?? []) as [`0x${string}`, ...`0x${string}`[]],
         data: (parsedFields.data ?? '0x') as `0x${string}`,
+        blockNumber: parsedFields.blockNumber ? BigInt(parsedFields.blockNumber) : 0n,
+        transactionHash: (parsedFields.transactionHash ?? '0x') as `0x${string}`,
         transactionIds,
       });
     }

--- a/src/app/api/webhooks/processWebhookEvents.ts
+++ b/src/app/api/webhooks/processWebhookEvents.ts
@@ -5,16 +5,19 @@ import { Event } from 'src/app/governance/events';
 import { CacheKeys } from 'src/config/consts';
 import { Addresses } from 'src/config/contracts';
 import database from 'src/config/database';
-import { votesTable } from 'src/db/schema';
-import fetchHistoricalEventsAndSaveToDBProgressively from 'src/features/governance/fetchHistoricalEventsAndSaveToDBProgressively';
-import fetchHistoricalMultiSigEventsAndSaveToDBProgressively from 'src/features/governance/fetchHistoricalMultiSigEventsAndSaveToDBProgressively';
+import { eventsTable, votesTable } from 'src/db/schema';
 import updateApprovalsInDB from 'src/features/governance/updateApprovalsInDB';
 import updateProposalsInDB from 'src/features/governance/updateProposalsInDB';
-import { IngestSource } from 'src/features/governance/utils/events/ingest';
+import {
+  ingestedViaConflictSet,
+  IngestSource,
+  withIngestionMetadata,
+} from 'src/features/governance/utils/events/ingest';
 import { decodeAndPrepareProposalEvent } from 'src/features/governance/utils/events/proposal';
 import { decodeAndPrepareVoteEvent } from 'src/features/governance/utils/events/vote';
 import { celoPublicClient } from 'src/utils/client';
-import { GetContractEventsParameters } from 'viem';
+import 'src/vendor/polyfill'; // BigInt.prototype.toJSON so bigint args serialize into jsonb
+import { decodeEventLog, GetContractEventsParameters } from 'viem';
 
 type GovernanceEventName = Exclude<
   GetContractEventsParameters<typeof governanceABI>['eventName'],
@@ -33,6 +36,8 @@ export type ParsedEvent = {
   contractAddress: string;
   topics: [`0x${string}`, ...`0x${string}`[]];
   data: `0x${string}`;
+  blockNumber: bigint;
+  transactionHash: `0x${string}`;
   transactionIds: bigint[];
 };
 
@@ -58,37 +63,18 @@ export async function processWebhookEvents(
       event.contractAddress.toLowerCase() === approverMultisigAddress.toLowerCase() &&
       MULTISIG_EVENT_NAMES.has(event.name);
 
+    // Persist the delivered event straight from the webhook payload. Previously every
+    // delivery triggered a cursor->head eth_getLogs scan to ingest events, but public
+    // forno rejects wide ranges ("query exceeds range") and the payload already carries
+    // the full log — so we store it directly. The hourly cron remains the catch-up
+    // backfill that fills any gap from a missed delivery.
+    await saveWebhookEvent(event, isMultiSigEvent, source);
+
     if (isMultiSigEvent) {
-      // Process MultiSig events - use backfill result to capture ALL new transactionIds,
-      // not just the one from the webhook event. This prevents missed approvals when the
-      // backfill advances progress past events that the webhook didn't specifically trigger for.
-      const backfillResult = await fetchHistoricalMultiSigEventsAndSaveToDBProgressively(
-        event.name,
-        celoPublicClient,
-        { source },
-      );
-
-      for (const txId of backfillResult.transactionIds) {
-        multisigTxIdsToProcess.add(txId);
-      }
-
-      // Also extract transactionIds from the webhook event itself as a fallback
       for (const txId of event.transactionIds) {
         multisigTxIdsToProcess.add(txId);
       }
     } else {
-      // Process Governance events - capture backfill proposalIds to ensure we update
-      // proposals that the backfill discovered (not just the webhook event itself).
-      const backfillProposalIds = await fetchHistoricalEventsAndSaveToDBProgressively(
-        event.name,
-        celoPublicClient,
-        undefined,
-        source,
-      );
-      for (const id of backfillProposalIds) {
-        proposalIdsToUpdate.add(id);
-      }
-
       const eventData = { topics: event.topics, data: event.data } as unknown as Event;
 
       // NOTE: for clarity, we don't need to parallelize `handleXXXEvent`
@@ -124,6 +110,45 @@ export async function processWebhookEvents(
   if (proposalIdsToUpdate.size) {
     await updateProposalsInDB(celoPublicClient, [...proposalIdsToUpdate], 'update');
   }
+}
+
+/**
+ * Stores a single webhook-delivered event into the events table, decoding its
+ * args from topics+data so downstream queries (e.g. args->>'proposalId') keep
+ * working. Dedupes on the (eventName, transactionHash, chainId) primary key and
+ * records ingestion provenance via ingestedVia.
+ */
+async function saveWebhookEvent(event: ParsedEvent, isMultiSig: boolean, source: IngestSource) {
+  let args: Record<string, unknown> = {};
+  try {
+    const decoded = decodeEventLog({
+      abi: isMultiSig ? multiSigABI : governanceABI,
+      topics: event.topics,
+      data: event.data,
+      strict: false,
+    });
+    args = (decoded.args ?? {}) as Record<string, unknown>;
+  } catch {
+    // Persist topics/data even if decoding fails; the cron backfill can self-heal args later.
+  }
+
+  const row = {
+    eventName: event.name,
+    args,
+    address: event.contractAddress,
+    topics: event.topics,
+    data: event.data,
+    blockNumber: event.blockNumber,
+    transactionHash: event.transactionHash,
+  };
+
+  await database
+    .insert(eventsTable)
+    .values(withIngestionMetadata([row], celoPublicClient.chain.id, source))
+    .onConflictDoUpdate({
+      target: [eventsTable.eventName, eventsTable.transactionHash, eventsTable.chainId],
+      set: ingestedViaConflictSet,
+    });
 }
 
 async function upsertVotes(rows: (typeof votesTable)['$inferInsert'][]) {


### PR DESCRIPTION
## Why

Every webhook delivery ran `fetchHistorical{,MultiSig}…Progressively`, which scans event history via `eth_getLogs` from the cursor to head — **the events table was written by that scan, not the payload**. So one delivery became a wide `getLogs` range. Public forno rejects wide ranges:

```
{"code":-32602,"message":"query exceeds range, retry smaller"}
→ Halved step 50000…1562 → "Retried too many times" → 500
```

Result: **every Alchemy + MultiBaas delivery 500'd**, real-time ingestion never landed, and the DB stayed fresh only via the hourly cron (~1–2h lag). This is the real root cause of the CGP-239/#295 "Expired" lag.

The webhook payload already carries the full log (`topics`, `data`, `blockNumber`, `transactionHash`, decodable args). The **original author even left a note**: `// in theory we _could_ just insert the rawFields directly in the db…`. This PR does exactly that.

## What

- **`processWebhookEvents` stores each delivered event directly** (`saveWebhookEvent`: decode args from topics+data, insert with `ingestedVia`, dedupe on the `(eventName, transactionHash, chainId)` PK). **No `fetchHistorical` scan, no `getLogs`, no range limit.**
- `ParsedEvent` now carries `blockNumber` + `transactionHash`; both routes populate them (alchemy from the log/parent block, multibaas from `rawFields`).
- `transactionIds` / `proposalIds` come **solely from the delivered payload**.
- **The hourly cron stays the catch-up backfill** for any missed delivery — so we keep the self-healing without scanning on every webhook.

Stored rows are identical in shape to the scan's (args decoded the same way; `BigInt.prototype.toJSON` polyfill imported so bigint args serialize into jsonb).

## Supersedes #495
#495 moved the scan to the archive node. This removes the scan from the webhook entirely, so no archive client is needed there. **Close #495 in favour of this.**

## Tests
Reworked for direct-insert semantics (txIds/proposalIds from payload; no backfill assertions). **34 webhook tests pass; 62 in the wider sweep** (webhooks + governance utils + stage cron). tsc + prettier clean.

## Verify after deploy
- Alchemy dashboard: `500 → 200`.
- prod `events.ingestedVia` shows `alchemy`/`multibaas` within seconds of a governance event; cursor tracks head (lag collapses from ~1–2h).