### PR TITLE
fix: read voter reward commission, not legacy validator commission

### DIFF
--- a/src/features/validators/useValidatorGroups.ts
+++ b/src/features/validators/useValidatorGroups.ts
@@ -25,6 +25,23 @@ import { PublicClient } from 'viem';
 import { usePublicClient } from 'wagmi';
 import { Validator, ValidatorGroup, ValidatorStatus } from './types';
 
+// The voter reward commission introduced by the commission CGP is not yet in
+// the installed @celo/abis (validatorsABI). Minimal fragment for reading it.
+// Returns [current, pending, activationBlock]; current/pending are Fixidity.
+const voterRewardCommissionABI = [
+  {
+    type: 'function',
+    stateMutability: 'view',
+    name: 'getVoterRewardCommission',
+    inputs: [{ name: 'group', type: 'address' }],
+    outputs: [
+      { name: '', type: 'uint256' },
+      { name: '', type: 'uint256' },
+      { name: '', type: 'uint256' },
+    ],
+  },
+] as const;
+
 export function useValidatorGroups(includeStCeloDefault: boolean = false) {
   const publicClient = usePublicClient();
   const { isLoading, isError, error, data } = useQuery({
@@ -389,32 +406,55 @@ async function fetchNamesForAccounts(publicClient: PublicClient, addresses: read
 }
 
 async function fetchGroupDetails(publicClient: PublicClient, addresses: readonly Address[]) {
-  const results = await publicClient.multicall({
-    contracts: addresses.map(
-      (addr) =>
-        ({
-          address: Addresses.Validators,
-          abi: validatorsABI,
-          functionName: 'getValidatorGroup',
-          args: [addr],
-        }) as const,
-    ),
-    allowFailure: true,
-  });
-  // getValidatorGroup returns: [members, commission, nextCommission,
-  // nextCommissionBlock, sizeHistory, slashingMultiplier, lastSlashed].
-  // commission is the voter reward commission in Fixidity format.
-  return results.map((n) => {
-    const result = n.result as
+  const [groupResults, commissionResults] = await Promise.all([
+    publicClient.multicall({
+      contracts: addresses.map(
+        (addr) =>
+          ({
+            address: Addresses.Validators,
+            abi: validatorsABI,
+            functionName: 'getValidatorGroup',
+            args: [addr],
+          }) as const,
+      ),
+      allowFailure: true,
+    }),
+    publicClient.multicall({
+      contracts: addresses.map(
+        (addr) =>
+          ({
+            address: Addresses.Validators,
+            abi: voterRewardCommissionABI,
+            functionName: 'getVoterRewardCommission',
+            args: [addr],
+          }) as const,
+      ),
+      allowFailure: true,
+    }),
+  ]);
+
+  return addresses.map((_addr, i) => {
+    // getValidatorGroup returns: [members, commission, nextCommission,
+    // nextCommissionBlock, sizeHistory, slashingMultiplier, lastSlashed].
+    // result[1] is the legacy validator-reward commission, NOT what we want;
+    // we only read lastSlashed here.
+    const groupResult = groupResults[i]?.result as
       | [Address, bigint, bigint, bigint, bigint[], bigint, bigint]
       | undefined;
-    if (!result || !Array.isArray(result) || result.length < 7) {
-      return { lastSlashed: null, commission: 0 };
-    }
-    return {
-      lastSlashed: Number(result[6]) * 1000,
-      commission: fromFixidity(result[1]),
-    };
+    const lastSlashed =
+      groupResult && Array.isArray(groupResult) && groupResult.length >= 7
+        ? Number(groupResult[6]) * 1000
+        : null;
+
+    // getVoterRewardCommission returns [current, pending, activationBlock];
+    // current/pending are Fixidity. We display the currently active rate.
+    const commissionResult = commissionResults[i]?.result as
+      | readonly [bigint, bigint, bigint]
+      | undefined;
+    const commission =
+      commissionResult && Array.isArray(commissionResult) ? fromFixidity(commissionResult[0]) : 0;
+
+    return { lastSlashed, commission };
   });
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #497. That PR shipped the Commission column but was squash-merged **before** the data-source fix landed, so `main` currently reads the **legacy validator-reward commission** (`getValidatorGroup` result[1]) — the one CGP 271 eliminated — instead of the new **voter reward commission** the commission CGP introduced.

This corrects the source to `Validators.getVoterRewardCommission(group)` → `[current, pending, activationBlock]`; we display the **current (active)** rate. See [forum](https://forum.celo.org/t/validator-group-voter-reward-commission/13392), [celo-monorepo#11694](https://github.com/celo-org/celo-monorepo/pull/11694).

`getVoterRewardCommission` is not yet in the installed `@celo/abis` (14.0.1), so a minimal inline ABI fragment is used. `lastSlashed` is still sourced from `getValidatorGroup` in the same batched round.

## Changes

- `useValidatorGroups.ts` only: `fetchGroupLastSlashed` → `fetchGroupDetails`, reads voter reward commission alongside the group lookup (two parallel multicalls). Adds the inline `voterRewardCommissionABI` fragment.

(The type field, table column, detail-page stat, `formatCommission` helper, and tests already landed via #497.)

## Verified on a local anvil fork

Forked the L2 chain, impersonated the Validators owner to drop `commissionUpdateDelay`, set commissions on two groups, and loaded the UI against the fork:

- **Ledger by Figment → 6%**, **Manta Labs → 2.5%**, all others 0%
- Top-9 collapsed row aggregate: **0.94%** = mean(6 + 2.5 + 7×0)/9 ✓
- Detail page `/staking/…` shows **Commission 6%**

Mainnet reality: 0/69 registered groups have set any voter reward commission yet (CGP just landed), which is why nothing shows against live data today.

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean (only pre-existing unrelated `StakeForm.tsx` warning)
- [x] `yarn build:app` — succeeds (exit 0)
- [x] `vitest run` on `utils.test.ts` — 11 pass
- [x] On-chain `getVoterRewardCommission` signature verified against mainnet Validators via `cast`
- [x] Rendered correctly against an anvil fork with non-zero commissions set