### PR TITLE
feat(buyback): add CELO buyback & burn dashboard

### DIFF
--- a/.github/workflows/refresh-buyback-dune-query.yml
+++ b/.github/workflows/refresh-buyback-dune-query.yml
@@ -1,0 +1,24 @@
+name: Refresh Buyback Dune Query
+
+# Re-executes the Dune P&L query (id 6898547) that powers the /buyback
+# dashboard, so its data is at most a day old. The app itself only reads the
+# query's cached results and never spends execution credits.
+
+on:
+  schedule:
+    # Run daily at 05:30 UTC (after the previous UTC day is complete and
+    # Dune's ingestion has caught up)
+    - cron: '30 5 * * *'
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  execute-query:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Execute Dune query 6898547
+        run: |
+          curl --fail-with-body -X POST "https://api.dune.com/api/v1/query/6898547/execute" \
+            -H "X-Dune-API-Key: ${{ secrets.DUNE_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{"performance": "medium"}'

--- a/example.env
+++ b/example.env
@@ -52,6 +52,11 @@ GITHUB_REPO_NAME=""
 # Slack bot token (Optional - used for production alerts)
 SLACK_TOKEN=""
 
+# Dune Analytics API key (Optional - powers the /buyback dashboard)
+# Reads the latest results of the Celo L2 sequencer-fee P&L query (id 6898547).
+# Get yours at https://dune.com/settings/api
+DUNE_API_KEY=""
+
 # ===========================
 # SCRIPTS ONLY
 # ===========================

--- a/src/app/api/buyback/route.ts
+++ b/src/app/api/buyback/route.ts
@@ -1,5 +1,5 @@
 import { computeBuybackStats } from 'src/features/buyback/computeStats';
-import { fetchDuneFeeRows, refreshDuneQueryIfStale } from 'src/features/buyback/fetchDuneResults';
+import { fetchDuneFeeRows } from 'src/features/buyback/fetchDuneResults';
 import { logger } from 'src/utils/logger';
 import { errorToString } from 'src/utils/strings';
 
@@ -15,12 +15,8 @@ export async function GET() {
   try {
     logger.debug('Buyback stats request received');
 
-    const { rows, executionEndedAt } = await fetchDuneFeeRows(apiKey);
+    const { rows } = await fetchDuneFeeRows(apiKey);
     const stats = computeBuybackStats(rows, new Date().toISOString());
-
-    // Serve the current results immediately; if they're older than a day this
-    // kicks off a Dune re-execution so a later visitor gets fresh data.
-    await refreshDuneQueryIfStale(apiKey, executionEndedAt);
 
     logger.debug(`Buyback stats computed from ${rows.length} daily rows`);
 

--- a/src/app/api/buyback/route.ts
+++ b/src/app/api/buyback/route.ts
@@ -1,5 +1,5 @@
 import { computeBuybackStats } from 'src/features/buyback/computeStats';
-import { fetchDuneFeeRows } from 'src/features/buyback/fetchDuneResults';
+import { fetchDuneFeeRows, refreshDuneQueryIfStale } from 'src/features/buyback/fetchDuneResults';
 import { logger } from 'src/utils/logger';
 import { errorToString } from 'src/utils/strings';
 
@@ -15,8 +15,12 @@ export async function GET() {
   try {
     logger.debug('Buyback stats request received');
 
-    const rows = await fetchDuneFeeRows(apiKey);
+    const { rows, executionEndedAt } = await fetchDuneFeeRows(apiKey);
     const stats = computeBuybackStats(rows, new Date().toISOString());
+
+    // Serve the current results immediately; if they're older than a day this
+    // kicks off a Dune re-execution so a later visitor gets fresh data.
+    await refreshDuneQueryIfStale(apiKey, executionEndedAt);
 
     logger.debug(`Buyback stats computed from ${rows.length} daily rows`);
 

--- a/src/app/api/buyback/route.ts
+++ b/src/app/api/buyback/route.ts
@@ -1,0 +1,30 @@
+import { computeBuybackStats } from 'src/features/buyback/computeStats';
+import { fetchDuneFeeRows } from 'src/features/buyback/fetchDuneResults';
+import { logger } from 'src/utils/logger';
+import { errorToString } from 'src/utils/strings';
+
+export const revalidate = 900; // Cache response for 15 minutes
+
+export async function GET() {
+  const apiKey = process.env.DUNE_API_KEY;
+  if (!apiKey) {
+    logger.warn('Buyback stats requested but DUNE_API_KEY is not configured');
+    return new Response('DUNE_API_KEY not configured', { status: 503 });
+  }
+
+  try {
+    logger.debug('Buyback stats request received');
+
+    const rows = await fetchDuneFeeRows(apiKey);
+    const stats = computeBuybackStats(rows, new Date().toISOString());
+
+    logger.debug(`Buyback stats computed from ${rows.length} daily rows`);
+
+    return Response.json(stats);
+  } catch (error) {
+    logger.error('Buyback stats error', error);
+    return new Response(`Unable to load buyback stats: ${errorToString(error)}`, {
+      status: 500,
+    });
+  }
+}

--- a/src/app/buyback/page.tsx
+++ b/src/app/buyback/page.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { SkeletonBlock } from 'src/components/animation/Skeleton';
+import { A_Blank } from 'src/components/buttons/A_Blank';
+import { Section } from 'src/components/layout/Section';
+import { CeloGlyph } from 'src/components/logos/Celo';
+import { H1 } from 'src/components/text/headers';
+import { PeriodStats } from 'src/features/buyback/types';
+import { useBuybackStats } from 'src/features/buyback/useBuybackStats';
+
+const usd0 = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
+const price3 = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 3,
+  maximumFractionDigits: 3,
+});
+
+function fmtUsd(value?: number): string {
+  return value == null ? '—' : `${usd0.format(Math.round(value))} USD`;
+}
+
+function fmtCelo(value?: number): string {
+  return value == null ? '—' : `${usd0.format(Math.round(value))} CELO`;
+}
+
+function fmtPrice(value?: number): string {
+  return value == null || value === 0 ? '—' : `${price3.format(value)} USD`;
+}
+
+interface Metric {
+  label: string;
+  total: string;
+  last24h: string;
+}
+
+function buildMetrics(totals?: PeriodStats, last24h?: PeriodStats | null): Metric[] {
+  return [
+    {
+      label: 'Fees collected',
+      total: fmtUsd(totals?.feesCollectedUsd),
+      last24h: fmtUsd(last24h?.feesCollectedUsd),
+    },
+    {
+      label: 'Fees after basic expenses',
+      total: fmtUsd(totals?.feesAfterExpensesUsd),
+      last24h: fmtUsd(last24h?.feesAfterExpensesUsd),
+    },
+    {
+      label: 'CELO bought and burned',
+      total: fmtCelo(totals?.celoBoughtAndBurned),
+      last24h: fmtCelo(last24h?.celoBoughtAndBurned),
+    },
+    {
+      label: 'USD spent for CELO buyback and burn',
+      total: fmtUsd(totals?.usdSpentOnBuyback),
+      last24h: fmtUsd(last24h?.usdSpentOnBuyback),
+    },
+    {
+      label: 'Average CELO buyback price',
+      total: fmtPrice(totals?.avgBuybackPriceUsd),
+      last24h: fmtPrice(last24h?.avgBuybackPriceUsd),
+    },
+  ];
+}
+
+export default function Page() {
+  const { stats, isLoading, isError } = useBuybackStats();
+
+  return (
+    <Section className="mt-6" containerClassName="space-y-6 max-w-screen-md">
+      <div className="flex items-center space-x-3">
+        <CeloGlyph width={34} height={34} />
+        <H1>CELO Buyback &amp; Burn</H1>
+      </div>
+
+      <p className="max-w-xl text-sm text-taupe-600">
+        Celo L2 sequencer fees fund an on-going CELO buyback &amp; burn under{' '}
+        <A_Blank
+          href="https://forum.celo.org/t/celoccelerate-celo-tokenomics-proposal/13147"
+          className="underline"
+        >
+          CELOccelerate (CGP-286)
+        </A_Blank>
+        . Figures are derived from the same daily P&amp;L data as the operator distribution report.
+      </p>
+
+      {isError ? (
+        <ErrorNotice />
+      ) : isLoading ? (
+        <StatsSkeleton />
+      ) : (
+        <StatsTable metrics={buildMetrics(stats?.totals, stats?.last24h)} />
+      )}
+
+      <Footnote latestDay={stats?.latestDay} updatedAt={stats?.updatedAt} />
+    </Section>
+  );
+}
+
+function StatsTable({ metrics }: { metrics: Metric[] }) {
+  return (
+    <div className="overflow-hidden border border-taupe-300 bg-white">
+      <div className="grid grid-cols-[1fr_auto] items-center gap-x-4 border-b border-taupe-300 bg-taupe-100 px-4 py-3 text-xs uppercase tracking-wide text-taupe-600 sm:grid-cols-[1fr_9rem_9rem]">
+        <span>Metric</span>
+        <span className="text-right">Total</span>
+        <span className="hidden text-right sm:block">Last 24 hrs</span>
+      </div>
+      {metrics.map((m) => (
+        <div
+          key={m.label}
+          className="grid grid-cols-[1fr_auto] items-center gap-x-4 border-b border-taupe-300 px-4 py-3.5 last:border-b-0 sm:grid-cols-[1fr_9rem_9rem]"
+        >
+          <span className="text-sm">{m.label}</span>
+          <div className="flex flex-col items-end sm:contents">
+            <span className="text-right font-serif text-lg text-green-600 sm:text-xl">
+              {m.total}
+            </span>
+            <span className="text-right text-xs text-taupe-600 sm:font-serif sm:text-base sm:text-lg sm:text-green-600">
+              {m.last24h}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StatsSkeleton() {
+  return (
+    <div className="border border-taupe-300 bg-white">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center justify-between border-b border-taupe-300 px-4 py-3.5 last:border-b-0"
+        >
+          <SkeletonBlock className="h-5 w-48" />
+          <SkeletonBlock className="h-6 w-28" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ErrorNotice() {
+  return (
+    <div className="border border-taupe-300 bg-white p-6 text-center text-sm text-taupe-600">
+      Buyback stats are unavailable right now. The dashboard needs a Dune API key (
+      <span className="font-mono">DUNE_API_KEY</span>) to be configured on the server.
+    </div>
+  );
+}
+
+function Footnote({ latestDay, updatedAt }: { latestDay?: string | null; updatedAt?: string }) {
+  const parts: string[] = [];
+  if (latestDay) parts.push(`Data through ${latestDay}`);
+  if (updatedAt) parts.push(`updated ${new Date(updatedAt).toUTCString()}`);
+
+  return (
+    <p className="text-center text-xs text-taupe-600">
+      Source:{' '}
+      <A_Blank href="https://dune.com/queries/6898547" className="underline">
+        Dune query 6898547
+      </A_Blank>
+      {parts.length > 0 ? ` · ${parts.join(' · ')}` : ''}
+    </p>
+  );
+}

--- a/src/app/buyback/page.tsx
+++ b/src/app/buyback/page.tsx
@@ -151,7 +151,9 @@ function ErrorNotice() {
 
 function Footnote({ latestDay, updatedAt }: { latestDay?: string | null; updatedAt?: string }) {
   const parts: string[] = [];
-  if (latestDay) parts.push(`Data through ${latestDay}`);
+  // Dune returns the day as a full timestamp ("2026-06-18 00:00:00.000 UTC");
+  // only the date part is meaningful here.
+  if (latestDay) parts.push(`Data through ${latestDay.slice(0, 10)}`);
   if (updatedAt) parts.push(`updated ${new Date(updatedAt).toUTCString()}`);
 
   return (

--- a/src/app/buyback/page.tsx
+++ b/src/app/buyback/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import clsx from 'clsx';
 import { SkeletonBlock } from 'src/components/animation/Skeleton';
 import { A_Blank } from 'src/components/buttons/A_Blank';
 import { Section } from 'src/components/layout/Section';
@@ -14,22 +15,34 @@ const price3 = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 3,
 });
 
-function fmtUsd(value?: number): string {
-  return value == null ? '—' : `${usd0.format(Math.round(value))} USD`;
+// A rendered stat cell. Values can legitimately go negative (a day where L1
+// costs exceed revenue is a loss), so the sign travels with the text and the
+// table colors losses red instead of green.
+interface Cell {
+  text: string;
+  negative: boolean;
 }
 
-function fmtCelo(value?: number): string {
-  return value == null ? '—' : `${usd0.format(Math.round(value))} CELO`;
+function cell(text: string, value?: number): Cell {
+  return { text, negative: value != null && value < 0 };
 }
 
-function fmtPrice(value?: number): string {
-  return value == null || value === 0 ? '—' : `${price3.format(value)} USD`;
+function fmtUsd(value?: number): Cell {
+  return cell(value == null ? '—' : `${usd0.format(Math.round(value))} USD`, value);
+}
+
+function fmtCelo(value?: number): Cell {
+  return cell(value == null ? '—' : `${usd0.format(Math.round(value))} CELO`, value);
+}
+
+function fmtPrice(value?: number): Cell {
+  return cell(value == null || value === 0 ? '—' : `${price3.format(value)} USD`, value);
 }
 
 interface Metric {
   label: string;
-  total: string;
-  last24h: string;
+  total: Cell;
+  last24h: Cell;
 }
 
 function buildMetrics(totals?: PeriodStats, last24h?: PeriodStats | null): Metric[] {
@@ -111,11 +124,21 @@ function StatsTable({ metrics }: { metrics: Metric[] }) {
         >
           <span className="text-sm">{m.label}</span>
           <div className="flex flex-col items-end sm:contents">
-            <span className="text-right font-serif text-lg text-green-600 sm:text-xl">
-              {m.total}
+            <span
+              className={clsx(
+                'text-right font-serif text-lg sm:text-xl',
+                m.total.negative ? 'text-red-600' : 'text-green-600',
+              )}
+            >
+              {m.total.text}
             </span>
-            <span className="text-right text-xs text-taupe-600 sm:font-serif sm:text-base sm:text-lg sm:text-green-600">
-              {m.last24h}
+            <span
+              className={clsx(
+                'text-right text-xs text-taupe-600 sm:font-serif sm:text-lg',
+                m.last24h.negative ? 'sm:text-red-600' : 'sm:text-green-600',
+              )}
+            >
+              {m.last24h.text}
             </span>
           </div>
         </div>

--- a/src/app/buyback/page.tsx
+++ b/src/app/buyback/page.tsx
@@ -58,19 +58,19 @@ function buildMetrics(totals?: PeriodStats, last24h?: PeriodStats | null): Metri
       last24h: fmtUsd(last24h?.feesAfterExpensesUsd),
     },
     {
-      label: 'CELO bought and burned',
-      total: fmtCelo(totals?.celoBoughtAndBurned),
-      last24h: fmtCelo(last24h?.celoBoughtAndBurned),
+      label: 'CELO to the Community Fund',
+      total: fmtCelo(totals?.celoToCommunityFund),
+      last24h: fmtCelo(last24h?.celoToCommunityFund),
     },
     {
-      label: 'USD spent for CELO buyback and burn',
-      total: fmtUsd(totals?.usdSpentOnBuyback),
-      last24h: fmtUsd(last24h?.usdSpentOnBuyback),
+      label: 'USD value sent to the Community Fund',
+      total: fmtUsd(totals?.usdToCommunityFund),
+      last24h: fmtUsd(last24h?.usdToCommunityFund),
     },
     {
-      label: 'Average CELO buyback price',
-      total: fmtPrice(totals?.avgBuybackPriceUsd),
-      last24h: fmtPrice(last24h?.avgBuybackPriceUsd),
+      label: 'Average CELO price',
+      total: fmtPrice(totals?.avgCeloPriceUsd),
+      last24h: fmtPrice(last24h?.avgCeloPriceUsd),
     },
   ];
 }
@@ -82,18 +82,21 @@ export default function Page() {
     <Section className="mt-6" containerClassName="space-y-6 max-w-screen-md">
       <div className="flex items-center space-x-3">
         <CeloGlyph width={34} height={34} />
-        <H1>CELO Buyback &amp; Burn</H1>
+        <H1>CELO Buyback</H1>
       </div>
 
       <p className="max-w-xl text-sm text-taupe-600">
-        Celo L2 sequencer fees fund an on-going CELO buyback &amp; burn under{' '}
+        Under{' '}
         <A_Blank
           href="https://forum.celo.org/t/celoccelerate-celo-tokenomics-proposal/13147"
           className="underline"
         >
           CELOccelerate (CGP-286)
         </A_Blank>
-        . Figures are derived from the same daily P&amp;L data as the operator distribution report.
+        , Celo L2 sequencer fees — after L1 operating costs and the OP Superchain share — are used
+        to acquire CELO and sent to the Community Fund, where CELO holders govern their use (which
+        may include burning). Figures are derived from the same daily P&amp;L data as the operator
+        distribution report.
       </p>
 
       {isError ? (
@@ -112,7 +115,7 @@ export default function Page() {
 function StatsTable({ metrics }: { metrics: Metric[] }) {
   return (
     <div className="overflow-hidden border border-taupe-300 bg-white">
-      <div className="grid grid-cols-[1fr_auto] items-center gap-x-4 border-b border-taupe-300 bg-taupe-100 px-4 py-3 text-xs uppercase tracking-wide text-taupe-600 sm:grid-cols-[1fr_9rem_9rem]">
+      <div className="grid grid-cols-[1fr_auto] items-center gap-x-4 border-b border-taupe-300 bg-taupe-100 px-4 py-3 text-xs uppercase tracking-wide text-taupe-600 sm:grid-cols-[1fr_10rem_10rem]">
         <span>Metric</span>
         <span className="text-right">Total</span>
         <span className="hidden text-right sm:block">Last 24 hrs</span>
@@ -120,13 +123,13 @@ function StatsTable({ metrics }: { metrics: Metric[] }) {
       {metrics.map((m) => (
         <div
           key={m.label}
-          className="grid grid-cols-[1fr_auto] items-center gap-x-4 border-b border-taupe-300 px-4 py-3.5 last:border-b-0 sm:grid-cols-[1fr_9rem_9rem]"
+          className="grid grid-cols-[1fr_auto] items-center gap-x-4 border-b border-taupe-300 px-4 py-3.5 last:border-b-0 sm:grid-cols-[1fr_10rem_10rem]"
         >
           <span className="text-sm">{m.label}</span>
           <div className="flex flex-col items-end sm:contents">
             <span
               className={clsx(
-                'text-right font-serif text-lg sm:text-xl',
+                'whitespace-nowrap text-right font-serif text-lg sm:text-xl',
                 m.total.negative ? 'text-red-600' : 'text-green-600',
               )}
             >
@@ -134,7 +137,7 @@ function StatsTable({ metrics }: { metrics: Metric[] }) {
             </span>
             <span
               className={clsx(
-                'text-right text-xs text-taupe-600 sm:font-serif sm:text-lg',
+                'whitespace-nowrap text-right text-xs text-taupe-600 sm:font-serif sm:text-lg',
                 m.last24h.negative ? 'sm:text-red-600' : 'sm:text-green-600',
               )}
             >

--- a/src/app/buyback/page.tsx
+++ b/src/app/buyback/page.tsx
@@ -58,12 +58,12 @@ function buildMetrics(totals?: PeriodStats, last24h?: PeriodStats | null): Metri
       last24h: fmtUsd(last24h?.feesAfterExpensesUsd),
     },
     {
-      label: 'CELO to the Community Fund',
+      label: 'CELO accrued for the Community Fund',
       total: fmtCelo(totals?.celoToCommunityFund),
       last24h: fmtCelo(last24h?.celoToCommunityFund),
     },
     {
-      label: 'USD value sent to the Community Fund',
+      label: 'USD value accrued for the Community Fund',
       total: fmtUsd(totals?.usdToCommunityFund),
       last24h: fmtUsd(last24h?.usdToCommunityFund),
     },
@@ -94,9 +94,10 @@ export default function Page() {
           CELOccelerate (CGP-286)
         </A_Blank>
         , Celo L2 sequencer fees — after L1 operating costs and the OP Superchain share — are used
-        to acquire CELO and sent to the Community Fund, where CELO holders govern their use (which
-        may include burning). Figures are derived from the same daily P&amp;L data as the operator
-        distribution report.
+        to acquire CELO for the Community Fund, where CELO holders govern their use (which may
+        include burning). Figures show what has accrued from fees, derived from the same daily
+        P&amp;L data as the operator distribution report; actual transfers to the Community Fund
+        are executed in periodic batches.
       </p>
 
       {isError ? (

--- a/src/components/nav/NavBar.tsx
+++ b/src/components/nav/NavBar.tsx
@@ -19,6 +19,7 @@ import { useAccount } from 'wagmi';
 const LINKS = (isWalletConnected?: boolean) => [
   { label: 'Staking', to: '/', icon: Staking },
   { label: 'Governance', to: '/governance', icon: Governance },
+  { label: 'Buyback', to: '/buyback', icon: Dashboard, hideInMiniPay: true },
   { label: 'Delegate', to: '/delegate', icon: Delegate, hideInMiniPay: true },
   { label: 'Bridge', to: '/bridge', icon: Bridge, hideInMiniPay: true },
   { label: 'Names', to: 'https://names.celo.org', icon: ENS, hideInMiniPay: true },

--- a/src/features/buyback/computeStats.test.ts
+++ b/src/features/buyback/computeStats.test.ts
@@ -59,6 +59,17 @@ describe('computeDailyMetrics', () => {
     expect(m.buybackCelo).toBe(0);
   });
 
+  it('keeps losses negative when L1 costs exceed revenue, like report.py', () => {
+    // Same day but with 1 ETH of L1 cost = $1000 against $600 revenue.
+    const m = computeDailyMetrics({ ...dayRow, batcher_cost_eth: 1 });
+    expect(m.feesAfterExpensesUsd).toBeCloseTo(-400, 6);
+    expect(m.buybackUsd).toBeLessThan(0);
+    expect(m.buybackCelo).toBeLessThan(0);
+    // OP share falls back to the 2.5%-of-revenue floor on loss days.
+    // buyback_usd = 600 - 1000 - max(15, -60) = -415
+    expect(m.buybackUsd).toBeCloseTo(-415, 6);
+  });
+
   it('coerces string values from the Dune JSON payload', () => {
     const m = computeDailyMetrics({
       ...dayRow,
@@ -94,6 +105,14 @@ describe('aggregate', () => {
 
   it('returns 0 average when nothing was burned', () => {
     expect(aggregate([]).avgBuybackPriceUsd).toBe(0);
+  });
+
+  it('sums loss days signed and guards the average against non-positive burn', () => {
+    const loss = computeDailyMetrics({ ...dayRow, batcher_cost_eth: 1 });
+    const stats = aggregate([loss]);
+    expect(stats.usdSpentOnBuyback).toBeLessThan(0);
+    expect(stats.celoBoughtAndBurned).toBeLessThan(0);
+    expect(stats.avgBuybackPriceUsd).toBe(0);
   });
 });
 

--- a/src/features/buyback/computeStats.test.ts
+++ b/src/features/buyback/computeStats.test.ts
@@ -35,8 +35,8 @@ describe('computeDailyMetrics', () => {
     expect(m.feesCollectedUsd).toBeCloseTo(600, 6);
     expect(m.l1CostUsd).toBeCloseTo(50, 6);
     expect(m.feesAfterExpensesUsd).toBeCloseTo(550, 6);
-    expect(m.buybackCelo).toBeCloseTo(4675, 4);
-    expect(m.buybackUsd).toBeCloseTo(467.5, 6);
+    expect(m.communityFundCelo).toBeCloseTo(4675, 4);
+    expect(m.communityFundUsd).toBeCloseTo(467.5, 6);
   });
 
   it('uses hardcoded $1 pegs for stablecoins, ignoring missing Dune USD columns', () => {
@@ -56,18 +56,18 @@ describe('computeDailyMetrics', () => {
     expect(m.celoPriceUsd).toBe(0);
     expect(m.feesCollectedUsd).toBeCloseTo(100, 6);
     // Without a CELO price the CELO-denominated buyback is 0.
-    expect(m.buybackCelo).toBe(0);
+    expect(m.communityFundCelo).toBe(0);
   });
 
   it('keeps losses negative when L1 costs exceed revenue, like report.py', () => {
     // Same day but with 1 ETH of L1 cost = $1000 against $600 revenue.
     const m = computeDailyMetrics({ ...dayRow, batcher_cost_eth: 1 });
     expect(m.feesAfterExpensesUsd).toBeCloseTo(-400, 6);
-    expect(m.buybackUsd).toBeLessThan(0);
-    expect(m.buybackCelo).toBeLessThan(0);
+    expect(m.communityFundUsd).toBeLessThan(0);
+    expect(m.communityFundCelo).toBeLessThan(0);
     // OP share falls back to the 2.5%-of-revenue floor on loss days.
     // buyback_usd = 600 - 1000 - max(15, -60) = -415
-    expect(m.buybackUsd).toBeCloseTo(-415, 6);
+    expect(m.communityFundUsd).toBeCloseTo(-415, 6);
   });
 
   it('coerces string values from the Dune JSON payload', () => {
@@ -82,7 +82,7 @@ describe('computeDailyMetrics', () => {
 });
 
 describe('aggregate', () => {
-  it('weights the average buyback price by CELO volume', () => {
+  it('weights the average CELO price by volume', () => {
     const days = [
       { ...computeDailyMetrics(dayRow) },
       // Second day at a higher price: 1000 CELO @ $0.20, no other fees, no costs.
@@ -96,23 +96,23 @@ describe('aggregate', () => {
     ];
     const stats = aggregate(days);
     // avg = total USD spent / total CELO burned
-    expect(stats.avgBuybackPriceUsd).toBeCloseTo(
-      stats.usdSpentOnBuyback / stats.celoBoughtAndBurned,
+    expect(stats.avgCeloPriceUsd).toBeCloseTo(
+      stats.usdToCommunityFund / stats.celoToCommunityFund,
       10,
     );
-    expect(stats.celoBoughtAndBurned).toBeGreaterThan(0);
+    expect(stats.celoToCommunityFund).toBeGreaterThan(0);
   });
 
-  it('returns 0 average when nothing was burned', () => {
-    expect(aggregate([]).avgBuybackPriceUsd).toBe(0);
+  it('returns 0 average when nothing was distributed', () => {
+    expect(aggregate([]).avgCeloPriceUsd).toBe(0);
   });
 
-  it('sums loss days signed and guards the average against non-positive burn', () => {
+  it('sums loss days signed and guards the average against non-positive totals', () => {
     const loss = computeDailyMetrics({ ...dayRow, batcher_cost_eth: 1 });
     const stats = aggregate([loss]);
-    expect(stats.usdSpentOnBuyback).toBeLessThan(0);
-    expect(stats.celoBoughtAndBurned).toBeLessThan(0);
-    expect(stats.avgBuybackPriceUsd).toBe(0);
+    expect(stats.usdToCommunityFund).toBeLessThan(0);
+    expect(stats.celoToCommunityFund).toBeLessThan(0);
+    expect(stats.avgCeloPriceUsd).toBe(0);
   });
 });
 

--- a/src/features/buyback/computeStats.test.ts
+++ b/src/features/buyback/computeStats.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { aggregate, computeBuybackStats, computeDailyMetrics } from './computeStats';
+import { DuneFeeRow } from './types';
+
+// A single day: 1000 CELO fees @ $0.10, 500 USDT fees, and $50 of L1 cost.
+// celo_price      = 100 / 1000 = 0.10
+// revenue_usd     = 100 (CELO) + 500 (USDT) = 600
+// revenue_celo    = 600 / 0.10 = 6000
+// l1_usd          = 0.05 ETH * 1000 = 50 ; l1_celo = 50 / 0.10 = 500
+// op_profit_celo  = 6000 - 500 = 5500
+// op_share_celo   = max(0.025*6000, 0.15*5500) = max(150, 825) = 825
+// buyback_celo    = 6000 - 0 - 500 - 825 = 4675
+// buyback_usd     = 4675 * 0.10 = 467.5
+const dayRow: DuneFeeRow = {
+  day: '2026-05-01',
+  fee_CELO: 1000,
+  fee_USDT: 500,
+  fee_USDm: 0,
+  fee_EURm: 0,
+  fee_USDC: 0,
+  fee_CELO_usd: 100,
+  fee_EURm_usd: 0,
+  others_usd: 0,
+  batcher_cost_eth: 0.05,
+  proposer_cost_eth: 0,
+  challenger_cost_eth: 0,
+  EigenDA_cost_eth: 0,
+  eth_price_usd: 1000,
+};
+
+describe('computeDailyMetrics', () => {
+  it('computes P&L faithfully to report.py compute_row', () => {
+    const m = computeDailyMetrics(dayRow);
+    expect(m.celoPriceUsd).toBeCloseTo(0.1, 10);
+    expect(m.feesCollectedUsd).toBeCloseTo(600, 6);
+    expect(m.l1CostUsd).toBeCloseTo(50, 6);
+    expect(m.feesAfterExpensesUsd).toBeCloseTo(550, 6);
+    expect(m.buybackCelo).toBeCloseTo(4675, 4);
+    expect(m.buybackUsd).toBeCloseTo(467.5, 6);
+  });
+
+  it('uses hardcoded $1 pegs for stablecoins, ignoring missing Dune USD columns', () => {
+    // fee_CELO_usd omitted from revenue on the CELO side but USDT still pegs to $1.
+    const m = computeDailyMetrics({ ...dayRow, fee_USDT: 250, fee_CELO_usd: 100 });
+    // revenue = 100 + 250 = 350
+    expect(m.feesCollectedUsd).toBeCloseTo(350, 6);
+  });
+
+  it('handles a day with no CELO fees without dividing by zero', () => {
+    const m = computeDailyMetrics({
+      ...dayRow,
+      fee_CELO: 0,
+      fee_CELO_usd: 0,
+      fee_USDT: 100,
+    });
+    expect(m.celoPriceUsd).toBe(0);
+    expect(m.feesCollectedUsd).toBeCloseTo(100, 6);
+    // Without a CELO price the CELO-denominated buyback is 0.
+    expect(m.buybackCelo).toBe(0);
+  });
+
+  it('coerces string values from the Dune JSON payload', () => {
+    const m = computeDailyMetrics({
+      ...dayRow,
+      fee_CELO: '1000',
+      fee_CELO_usd: '100',
+      fee_USDT: '500',
+    } as unknown as DuneFeeRow);
+    expect(m.feesCollectedUsd).toBeCloseTo(600, 6);
+  });
+});
+
+describe('aggregate', () => {
+  it('weights the average buyback price by CELO volume', () => {
+    const days = [
+      { ...computeDailyMetrics(dayRow) },
+      // Second day at a higher price: 1000 CELO @ $0.20, no other fees, no costs.
+      computeDailyMetrics({
+        ...dayRow,
+        day: '2026-05-02',
+        fee_USDT: 0,
+        fee_CELO_usd: 200,
+        batcher_cost_eth: 0,
+      }),
+    ];
+    const stats = aggregate(days);
+    // avg = total USD spent / total CELO burned
+    expect(stats.avgBuybackPriceUsd).toBeCloseTo(
+      stats.usdSpentOnBuyback / stats.celoBoughtAndBurned,
+      10,
+    );
+    expect(stats.celoBoughtAndBurned).toBeGreaterThan(0);
+  });
+
+  it('returns 0 average when nothing was burned', () => {
+    expect(aggregate([]).avgBuybackPriceUsd).toBe(0);
+  });
+});
+
+describe('computeBuybackStats', () => {
+  it('sorts by day and exposes the latest day as last 24 hrs', () => {
+    const rows: DuneFeeRow[] = [
+      { ...dayRow, day: '2026-05-02', fee_CELO_usd: 200 },
+      { ...dayRow, day: '2026-05-01' },
+    ];
+    const stats = computeBuybackStats(rows, '2026-05-03T00:00:00.000Z');
+    expect(stats.latestDay).toBe('2026-05-02');
+    // last24h equals the aggregate of only the latest day
+    const latestOnly = aggregate([computeDailyMetrics(rows[0])]);
+    expect(stats.last24h?.feesCollectedUsd).toBeCloseTo(latestOnly.feesCollectedUsd, 6);
+    // totals sum both days
+    expect(stats.totals.feesCollectedUsd).toBeGreaterThan(stats.last24h!.feesCollectedUsd);
+  });
+
+  it('ignores rows without a day', () => {
+    const stats = computeBuybackStats([{ ...dayRow, day: '' }], 'now');
+    expect(stats.latestDay).toBeNull();
+    expect(stats.last24h).toBeNull();
+    expect(stats.totals.feesCollectedUsd).toBe(0);
+  });
+});

--- a/src/features/buyback/computeStats.ts
+++ b/src/features/buyback/computeStats.ts
@@ -1,0 +1,119 @@
+import { BuybackStats, DailyMetrics, DuneFeeRow, PeriodStats } from 'src/features/buyback/types';
+
+// Constants mirror scripts/sequencer-fees/report.py (celo-monorepo, CGP-286).
+// Stablecoins are valued at their USD peg; EURm keeps Dune's forex price.
+const STABLE_PEGS = { USDT: 1.0, USDC: 1.0, USDm: 1.0 } as const;
+// Carbon Fund fraction is 0% after CGP-288 paused those payments.
+const CARBON_FRACTION = 0.0;
+// OP Superchain revenue share: max(2.5% of revenue, 15% of profit-after-L1).
+const OP_SHARE_REVENUE_PCT = 0.025;
+const OP_SHARE_PROFIT_PCT = 0.15;
+
+function num(value: number | string | null | undefined): number {
+  if (value === null || value === undefined || value === '') return 0;
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Compute the derived P&L for a single day, faithful to report.py's
+ * `compute_row`. USD↔CELO conversions use that day's CELO price so aggregates
+ * stay accurate across price moves (non-linear because of the `max()` in the OP
+ * share).
+ */
+export function computeDailyMetrics(row: DuneFeeRow): DailyMetrics {
+  const feeCelo = num(row.fee_CELO);
+  const feeUsdt = num(row.fee_USDT);
+  const feeUsdm = num(row.fee_USDm);
+  const feeUsdc = num(row.fee_USDC);
+
+  const feeCeloUsd = num(row.fee_CELO_usd);
+  const feeEurmUsd = num(row.fee_EURm_usd);
+  const othersUsd = num(row.others_usd);
+
+  // Stablecoin USD values come from the hardcoded pegs, not Dune's price feed.
+  const feeUsdtUsd = feeUsdt * STABLE_PEGS.USDT;
+  const feeUsdcUsd = feeUsdc * STABLE_PEGS.USDC;
+  const feeUsdmUsd = feeUsdm * STABLE_PEGS.USDm;
+
+  const celoPriceUsd = feeCelo > 0 ? feeCeloUsd / feeCelo : 0;
+
+  const revenueUsd = feeCeloUsd + feeUsdtUsd + feeUsdmUsd + feeEurmUsd + feeUsdcUsd + othersUsd;
+  const revenueCelo = celoPriceUsd > 0 ? revenueUsd / celoPriceUsd : 0;
+
+  // L1 operating costs, converted from ETH at this day's ETH price.
+  const l1Eth =
+    num(row.batcher_cost_eth) +
+    num(row.proposer_cost_eth) +
+    num(row.challenger_cost_eth) +
+    num(row.EigenDA_cost_eth);
+  const ethPriceUsd = num(row.eth_price_usd);
+  const l1CostUsd = l1Eth * ethPriceUsd;
+  const l1CostCelo = celoPriceUsd > 0 ? l1CostUsd / celoPriceUsd : 0;
+
+  const carbonUsd = revenueUsd * CARBON_FRACTION;
+  const carbonCelo = revenueCelo * CARBON_FRACTION;
+
+  // Profit for the OP calc is revenue minus L1 (carbon is not deducted first).
+  const opProfitUsd = revenueUsd - l1CostUsd;
+  const opProfitCelo = revenueCelo - l1CostCelo;
+  const opShareUsd = Math.max(revenueUsd * OP_SHARE_REVENUE_PCT, opProfitUsd * OP_SHARE_PROFIT_PCT);
+  const opShareCelo = Math.max(
+    revenueCelo * OP_SHARE_REVENUE_PCT,
+    opProfitCelo * OP_SHARE_PROFIT_PCT,
+  );
+
+  // Net profit is what funds the CELO buyback & burn.
+  const buybackUsd = revenueUsd - (carbonUsd + l1CostUsd + opShareUsd);
+  const buybackCelo = revenueCelo - (carbonCelo + l1CostCelo + opShareCelo);
+
+  return {
+    day: row.day,
+    celoPriceUsd,
+    feesCollectedUsd: revenueUsd,
+    l1CostUsd,
+    feesAfterExpensesUsd: revenueUsd - l1CostUsd,
+    buybackUsd,
+    buybackCelo,
+  };
+}
+
+/** Sum a set of daily metrics into the dashboard's period figures. */
+export function aggregate(days: DailyMetrics[]): PeriodStats {
+  const feesCollectedUsd = days.reduce((s, d) => s + d.feesCollectedUsd, 0);
+  const feesAfterExpensesUsd = days.reduce((s, d) => s + d.feesAfterExpensesUsd, 0);
+  const celoBoughtAndBurned = days.reduce((s, d) => s + d.buybackCelo, 0);
+  const usdSpentOnBuyback = days.reduce((s, d) => s + d.buybackUsd, 0);
+  // Weighted average buyback price = total USD spent / total CELO bought.
+  const avgBuybackPriceUsd = celoBoughtAndBurned > 0 ? usdSpentOnBuyback / celoBoughtAndBurned : 0;
+
+  return {
+    feesCollectedUsd,
+    feesAfterExpensesUsd,
+    celoBoughtAndBurned,
+    usdSpentOnBuyback,
+    avgBuybackPriceUsd,
+  };
+}
+
+/**
+ * Turn raw Dune rows into the dashboard payload: all-time totals plus the most
+ * recent day as the "last 24 hrs" figure.
+ */
+export function computeBuybackStats(rows: DuneFeeRow[], updatedAt: string): BuybackStats {
+  const days = rows
+    .map(computeDailyMetrics)
+    .filter((d) => Boolean(d.day))
+    .sort((a, b) => a.day.localeCompare(b.day));
+
+  const totals = aggregate(days);
+  const latest = days.length > 0 ? days[days.length - 1] : null;
+  const last24h = latest ? aggregate([latest]) : null;
+
+  return {
+    totals,
+    last24h,
+    latestDay: latest?.day ?? null,
+    updatedAt,
+  };
+}

--- a/src/features/buyback/computeStats.ts
+++ b/src/features/buyback/computeStats.ts
@@ -63,9 +63,10 @@ export function computeDailyMetrics(row: DuneFeeRow): DailyMetrics {
     opProfitCelo * OP_SHARE_PROFIT_PCT,
   );
 
-  // Net profit is what funds the CELO buyback & burn.
-  const buybackUsd = revenueUsd - (carbonUsd + l1CostUsd + opShareUsd);
-  const buybackCelo = revenueCelo - (carbonCelo + l1CostCelo + opShareCelo);
+  // Net profit goes to the Community Fund (as CELO; the stablecoin portion is
+  // used to acquire CELO per CGP-286). Burning is a separate governance call.
+  const communityFundUsd = revenueUsd - (carbonUsd + l1CostUsd + opShareUsd);
+  const communityFundCelo = revenueCelo - (carbonCelo + l1CostCelo + opShareCelo);
 
   return {
     day: row.day,
@@ -73,8 +74,8 @@ export function computeDailyMetrics(row: DuneFeeRow): DailyMetrics {
     feesCollectedUsd: revenueUsd,
     l1CostUsd,
     feesAfterExpensesUsd: revenueUsd - l1CostUsd,
-    buybackUsd,
-    buybackCelo,
+    communityFundUsd,
+    communityFundCelo,
   };
 }
 
@@ -82,17 +83,17 @@ export function computeDailyMetrics(row: DuneFeeRow): DailyMetrics {
 export function aggregate(days: DailyMetrics[]): PeriodStats {
   const feesCollectedUsd = days.reduce((s, d) => s + d.feesCollectedUsd, 0);
   const feesAfterExpensesUsd = days.reduce((s, d) => s + d.feesAfterExpensesUsd, 0);
-  const celoBoughtAndBurned = days.reduce((s, d) => s + d.buybackCelo, 0);
-  const usdSpentOnBuyback = days.reduce((s, d) => s + d.buybackUsd, 0);
-  // Weighted average buyback price = total USD spent / total CELO bought.
-  const avgBuybackPriceUsd = celoBoughtAndBurned > 0 ? usdSpentOnBuyback / celoBoughtAndBurned : 0;
+  const celoToCommunityFund = days.reduce((s, d) => s + d.communityFundCelo, 0);
+  const usdToCommunityFund = days.reduce((s, d) => s + d.communityFundUsd, 0);
+  // Volume-weighted average CELO price = total USD value / total CELO.
+  const avgCeloPriceUsd = celoToCommunityFund > 0 ? usdToCommunityFund / celoToCommunityFund : 0;
 
   return {
     feesCollectedUsd,
     feesAfterExpensesUsd,
-    celoBoughtAndBurned,
-    usdSpentOnBuyback,
-    avgBuybackPriceUsd,
+    celoToCommunityFund,
+    usdToCommunityFund,
+    avgCeloPriceUsd,
   };
 }
 

--- a/src/features/buyback/fetchDuneResults.ts
+++ b/src/features/buyback/fetchDuneResults.ts
@@ -1,0 +1,47 @@
+import { DuneFeeRow } from 'src/features/buyback/types';
+
+const DUNE_API = 'https://api.dune.com/api/v1';
+
+// Celo Mainnet sequencer-fee P&L query (same source as report.py).
+export const CELO_PNL_QUERY_ID = 6898547;
+
+const PAGE_SIZE = 1000;
+const MAX_ROWS = 10_000; // safety cap: ~one row per day since L2 genesis
+
+interface DuneResultsResponse {
+  result?: { rows?: DuneFeeRow[] };
+}
+
+/**
+ * Read the latest cached results of the Dune P&L query. Uses the read-only
+ * `/results` endpoint so it never spends execution credits — the query is
+ * refreshed on Dune's own schedule. Paginates until the query is exhausted.
+ */
+export async function fetchDuneFeeRows(
+  apiKey: string,
+  queryId: number = CELO_PNL_QUERY_ID,
+): Promise<DuneFeeRow[]> {
+  const rows: DuneFeeRow[] = [];
+  let offset = 0;
+
+  while (rows.length < MAX_ROWS) {
+    const url = `${DUNE_API}/query/${queryId}/results?limit=${PAGE_SIZE}&offset=${offset}`;
+    const response = await fetch(url, {
+      headers: { 'X-Dune-API-Key': apiKey },
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Dune API ${response.status}: ${body.slice(0, 200)}`);
+    }
+
+    const data = (await response.json()) as DuneResultsResponse;
+    const batch = data.result?.rows ?? [];
+    rows.push(...batch);
+
+    if (batch.length < PAGE_SIZE) break;
+    offset += batch.length;
+  }
+
+  return rows;
+}

--- a/src/features/buyback/fetchDuneResults.ts
+++ b/src/features/buyback/fetchDuneResults.ts
@@ -1,5 +1,4 @@
 import { DuneFeeRow } from 'src/features/buyback/types';
-import { logger } from 'src/utils/logger';
 
 const DUNE_API = 'https://api.dune.com/api/v1';
 
@@ -8,11 +7,7 @@ export const CELO_PNL_QUERY_ID = 6898547;
 
 const PAGE_SIZE = 1000;
 const MAX_ROWS = 10_000; // safety cap: ~one row per day since L2 genesis
-
-// Re-execute the query when its last run is older than this. 20 hours (not 24)
-// so the daily refresh doesn't drift later each day — triggers only happen on
-// visits, so each refresh lands a bit after the threshold.
-const REFRESH_AFTER_MS = 20 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 30_000;
 
 interface DuneResultsResponse {
   execution_ended_at?: string;
@@ -27,7 +22,11 @@ export interface DuneFeeResults {
 
 /**
  * Read the latest cached results of the Dune P&L query via the read-only
- * `/results` endpoint. Paginates until the query is exhausted.
+ * `/results` endpoint, so a page visit never spends execution credits. The
+ * query itself is re-executed once a day by the refresh-buyback-dune-query
+ * GitHub Actions cron — deliberately not from this public request path, where
+ * cache-busting traffic could be used to burn Dune credits. Paginates until
+ * the query is exhausted.
  */
 export async function fetchDuneFeeRows(
   apiKey: string,
@@ -41,6 +40,7 @@ export async function fetchDuneFeeRows(
     const url = `${DUNE_API}/query/${queryId}/results?limit=${PAGE_SIZE}&offset=${offset}`;
     const response = await fetch(url, {
       headers: { 'X-Dune-API-Key': apiKey },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -58,44 +58,4 @@ export async function fetchDuneFeeRows(
   }
 
   return { rows, executionEndedAt };
-}
-
-// Last refresh trigger per server instance. Best-effort dedup only — on
-// serverless each instance has its own copy, but the route's response cache
-// already limits how often the check runs at all.
-let lastTriggeredAtMs = 0;
-
-/**
- * Keep the Dune data at most a day old: if the query's last execution is older
- * than the refresh threshold, kick off a new execution (spends one Dune
- * execution credit). Fire-and-forget from the caller's perspective — the
- * current request still serves the existing results; a later visitor picks up
- * the fresh ones once Dune finishes.
- */
-export async function refreshDuneQueryIfStale(
-  apiKey: string,
-  executionEndedAt: string | null,
-  queryId: number = CELO_PNL_QUERY_ID,
-): Promise<void> {
-  const endedAtMs = executionEndedAt ? Date.parse(executionEndedAt) : 0;
-  if (Number.isFinite(endedAtMs) && Date.now() - endedAtMs < REFRESH_AFTER_MS) return;
-  if (Date.now() - lastTriggeredAtMs < REFRESH_AFTER_MS) return;
-
-  lastTriggeredAtMs = Date.now();
-  try {
-    const response = await fetch(`${DUNE_API}/query/${queryId}/execute`, {
-      method: 'POST',
-      headers: { 'X-Dune-API-Key': apiKey, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ performance: 'medium' }),
-    });
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`Dune execute ${response.status}: ${body.slice(0, 200)}`);
-    }
-    logger.info(`Triggered Dune query ${queryId} refresh (last run: ${executionEndedAt})`);
-  } catch (error) {
-    // Reset the guard so the next request can retry the trigger.
-    lastTriggeredAtMs = 0;
-    logger.warn('Failed to trigger Dune query refresh', error);
-  }
 }

--- a/src/features/buyback/fetchDuneResults.ts
+++ b/src/features/buyback/fetchDuneResults.ts
@@ -1,4 +1,5 @@
 import { DuneFeeRow } from 'src/features/buyback/types';
+import { logger } from 'src/utils/logger';
 
 const DUNE_API = 'https://api.dune.com/api/v1';
 
@@ -8,20 +9,32 @@ export const CELO_PNL_QUERY_ID = 6898547;
 const PAGE_SIZE = 1000;
 const MAX_ROWS = 10_000; // safety cap: ~one row per day since L2 genesis
 
+// Re-execute the query when its last run is older than this. 20 hours (not 24)
+// so the daily refresh doesn't drift later each day — triggers only happen on
+// visits, so each refresh lands a bit after the threshold.
+const REFRESH_AFTER_MS = 20 * 60 * 60 * 1000;
+
 interface DuneResultsResponse {
+  execution_ended_at?: string;
   result?: { rows?: DuneFeeRow[] };
 }
 
+export interface DuneFeeResults {
+  rows: DuneFeeRow[];
+  /** When Dune last finished executing the query (ISO timestamp), if known. */
+  executionEndedAt: string | null;
+}
+
 /**
- * Read the latest cached results of the Dune P&L query. Uses the read-only
- * `/results` endpoint so it never spends execution credits — the query is
- * refreshed on Dune's own schedule. Paginates until the query is exhausted.
+ * Read the latest cached results of the Dune P&L query via the read-only
+ * `/results` endpoint. Paginates until the query is exhausted.
  */
 export async function fetchDuneFeeRows(
   apiKey: string,
   queryId: number = CELO_PNL_QUERY_ID,
-): Promise<DuneFeeRow[]> {
+): Promise<DuneFeeResults> {
   const rows: DuneFeeRow[] = [];
+  let executionEndedAt: string | null = null;
   let offset = 0;
 
   while (rows.length < MAX_ROWS) {
@@ -36,6 +49,7 @@ export async function fetchDuneFeeRows(
     }
 
     const data = (await response.json()) as DuneResultsResponse;
+    executionEndedAt ??= data.execution_ended_at ?? null;
     const batch = data.result?.rows ?? [];
     rows.push(...batch);
 
@@ -43,5 +57,45 @@ export async function fetchDuneFeeRows(
     offset += batch.length;
   }
 
-  return rows;
+  return { rows, executionEndedAt };
+}
+
+// Last refresh trigger per server instance. Best-effort dedup only — on
+// serverless each instance has its own copy, but the route's response cache
+// already limits how often the check runs at all.
+let lastTriggeredAtMs = 0;
+
+/**
+ * Keep the Dune data at most a day old: if the query's last execution is older
+ * than the refresh threshold, kick off a new execution (spends one Dune
+ * execution credit). Fire-and-forget from the caller's perspective — the
+ * current request still serves the existing results; a later visitor picks up
+ * the fresh ones once Dune finishes.
+ */
+export async function refreshDuneQueryIfStale(
+  apiKey: string,
+  executionEndedAt: string | null,
+  queryId: number = CELO_PNL_QUERY_ID,
+): Promise<void> {
+  const endedAtMs = executionEndedAt ? Date.parse(executionEndedAt) : 0;
+  if (Number.isFinite(endedAtMs) && Date.now() - endedAtMs < REFRESH_AFTER_MS) return;
+  if (Date.now() - lastTriggeredAtMs < REFRESH_AFTER_MS) return;
+
+  lastTriggeredAtMs = Date.now();
+  try {
+    const response = await fetch(`${DUNE_API}/query/${queryId}/execute`, {
+      method: 'POST',
+      headers: { 'X-Dune-API-Key': apiKey, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ performance: 'medium' }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Dune execute ${response.status}: ${body.slice(0, 200)}`);
+    }
+    logger.info(`Triggered Dune query ${queryId} refresh (last run: ${executionEndedAt})`);
+  } catch (error) {
+    // Reset the guard so the next request can retry the trigger.
+    lastTriggeredAtMs = 0;
+    logger.warn('Failed to trigger Dune query refresh', error);
+  }
 }

--- a/src/features/buyback/types.ts
+++ b/src/features/buyback/types.ts
@@ -1,0 +1,57 @@
+// Types for the CELO buyback & burn dashboard.
+//
+// Numbers mirror the per-day P&L computed by the sequencer-fee distribution
+// tooling in celo-monorepo (scripts/sequencer-fees, CGP-286 "CELOccelerate").
+// The dashboard is driven entirely by the Dune P&L query (id 6898547) — the
+// same daily fee/cost dataset the operator report reads.
+
+/** One daily row as returned by the Dune P&L query (id 6898547). */
+export interface DuneFeeRow {
+  day: string;
+  fee_CELO: number | string | null;
+  fee_USDT: number | string | null;
+  fee_USDm: number | string | null;
+  fee_EURm: number | string | null;
+  fee_USDC: number | string | null;
+  fee_CELO_usd: number | string | null;
+  fee_EURm_usd: number | string | null;
+  others_usd: number | string | null;
+  batcher_cost_eth: number | string | null;
+  proposer_cost_eth: number | string | null;
+  challenger_cost_eth: number | string | null;
+  EigenDA_cost_eth: number | string | null;
+  eth_price_usd: number | string | null;
+}
+
+/** Derived P&L for a single day. */
+export interface DailyMetrics {
+  day: string;
+  celoPriceUsd: number;
+  /** Total fee revenue in USD (CELO fees + stablecoin fees). */
+  feesCollectedUsd: number;
+  /** L1 operating costs (batcher + proposer + challenger + EigenDA), in USD. */
+  l1CostUsd: number;
+  /** Revenue minus basic (L1) expenses, in USD. */
+  feesAfterExpensesUsd: number;
+  /** Net profit distributed to buy back & burn CELO, in USD. */
+  buybackUsd: number;
+  /** Net profit expressed as CELO bought & burned at that day's price. */
+  buybackCelo: number;
+}
+
+/** Aggregated dashboard figures for a period (all-time or last 24 hrs). */
+export interface PeriodStats {
+  feesCollectedUsd: number;
+  feesAfterExpensesUsd: number;
+  celoBoughtAndBurned: number;
+  usdSpentOnBuyback: number;
+  avgBuybackPriceUsd: number;
+}
+
+/** Full dashboard payload returned by the API route. */
+export interface BuybackStats {
+  totals: PeriodStats;
+  last24h: PeriodStats | null;
+  latestDay: string | null;
+  updatedAt: string;
+}

--- a/src/features/buyback/types.ts
+++ b/src/features/buyback/types.ts
@@ -33,19 +33,23 @@ export interface DailyMetrics {
   l1CostUsd: number;
   /** Revenue minus basic (L1) expenses, in USD. */
   feesAfterExpensesUsd: number;
-  /** Net profit distributed to buy back & burn CELO, in USD. */
-  buybackUsd: number;
-  /** Net profit expressed as CELO bought & burned at that day's price. */
-  buybackCelo: number;
+  /**
+   * Net profit destined for the Community Fund, in USD. Per CGP-286 the
+   * stablecoin portion is used to acquire CELO; burning is a separate
+   * governance decision, not part of the distribution.
+   */
+  communityFundUsd: number;
+  /** Net profit expressed as CELO at that day's price. */
+  communityFundCelo: number;
 }
 
 /** Aggregated dashboard figures for a period (all-time or last 24 hrs). */
 export interface PeriodStats {
   feesCollectedUsd: number;
   feesAfterExpensesUsd: number;
-  celoBoughtAndBurned: number;
-  usdSpentOnBuyback: number;
-  avgBuybackPriceUsd: number;
+  celoToCommunityFund: number;
+  usdToCommunityFund: number;
+  avgCeloPriceUsd: number;
 }
 
 /** Full dashboard payload returned by the API route. */

--- a/src/features/buyback/useBuybackStats.ts
+++ b/src/features/buyback/useBuybackStats.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { BuybackStats } from 'src/features/buyback/types';
+
+export function useBuybackStats(): {
+  stats: BuybackStats | undefined;
+  isLoading: boolean;
+  isError: boolean;
+} {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['buyback', 'stats'],
+    queryFn: async () => {
+      const response = await fetch('/api/buyback');
+      if (!response.ok) {
+        throw new Error('Failed to fetch buyback stats');
+      }
+      return response.json() as Promise<BuybackStats>;
+    },
+    staleTime: 15 * 60 * 1000, // 15 minutes
+    refetchInterval: 15 * 60 * 1000, // Refetch every 15 minutes
+    retry: false,
+  });
+
+  return { stats: data, isLoading, isError };
+}


### PR DESCRIPTION
## Summary

Adds a public **`/buyback`** page showing Celo L2 sequencer-fee revenue and the resulting CELO buyback & burn, per [CGP-286 (CELOccelerate)](https://forum.celo.org/t/celoccelerate-celo-tokenomics-proposal/13147). Inspired by the community mockup asking for Celo Core Co. fee/burn stats.

Metrics come from the **same daily P&L data as the operator distribution tooling** (celo-monorepo `scripts/sequencer-fees`, [PR #11774](https://github.com/celo-org/celo-monorepo/pull/11774)) — the Dune P&L query `6898547`. The per-day computation mirrors `report.py`'s `compute_row`.

## What it shows

All-time totals + last 24 hrs:

| Metric | Definition |
|---|---|
| Fees collected | CELO fees + stablecoin fees (USD) |
| Fees after basic expenses | revenue − L1 operating costs (batcher + proposer + challenger + EigenDA) |
| CELO bought and burned | net profit expressed as CELO |
| USD spent for buyback and burn | net profit in USD |
| Average buyback price | volume-weighted (Σ USD ÷ Σ CELO) |

Faithful to the script math: `OP_share = max(2.5%·revenue, 15%·(revenue − L1))`, carbon = 0% (post-CGP-288), stablecoins at $1.00 peg. USD↔CELO conversions happen **per day at that day's price** before summing — required because the `max()` in the OP share makes period-total conversion inaccurate.

## Architecture

Mirrors the existing `stCelo/apy` pattern (pure calc → API route → React Query hook → client page):

- `src/features/buyback/computeStats.ts` — pure, I/O-free P&L calc (unit-tested)
- `src/features/buyback/fetchDuneResults.ts` — read-only Dune `/results` fetch (no execution credits, paginated)
- `src/app/api/buyback/route.ts` — glue + 15-min cache; returns 503 when key unset
- `src/features/buyback/useBuybackStats.ts` — React Query hook
- `src/app/buyback/page.tsx` — dashboard reusing existing UI primitives (`Section`, `H1`, `SkeletonBlock`, `taupe`/`green` tokens); no new assets
- NavBar link added

Needs **no DB and no RPC** — only Dune.

## Config

Requires `DUNE_API_KEY` (added to `example.env`). Without it the page degrades gracefully to a "needs Dune key" notice. Set it in Vercel + local `.env.local`.

## Test plan

- [x] `vitest` — 8 unit tests on the P&L calc pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Dev smoke: `/api/buyback` → 503 with clear message (no key); `/buyback` → 200 compiles
- [ ] Set `DUNE_API_KEY` in preview env and verify real numbers render