### PR TITLE
chore: upgrade Node.js to v24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: yarn-install
         # Check out the lockfile from main, reinstall, and then
@@ -39,12 +42,15 @@ jobs:
     needs: [install]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: build
         run: |
@@ -60,12 +66,15 @@ jobs:
     needs: [install]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: validate delegates metadata
         run: |
@@ -82,12 +91,15 @@ jobs:
     needs: [install]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: prettier
         run: |
@@ -104,12 +116,15 @@ jobs:
     needs: [install]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: lint
         run: yarn run lint
@@ -127,7 +142,7 @@ jobs:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
       - uses: foundry-rs/foundry-toolchain@v1
       - name: test
         run: yarn run test
@@ -161,7 +176,7 @@ jobs:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
       - name: Run database migrations
         run: yarn migrate
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -16,12 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: yarn-install
         # Check out the lockfile from main, reinstall, and then
@@ -49,12 +52,15 @@ jobs:
       NODE_ENV: production
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: backfill-db-production
         id: backfill-db-prod
@@ -88,12 +94,15 @@ jobs:
       NODE_ENV: production
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: backfill-db-staging
         id: backfill-db-staging

--- a/.github/workflows/populate-staging-testdata.yml
+++ b/.github/workflows/populate-staging-testdata.yml
@@ -28,12 +28,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: yarn-install
         run: |
@@ -44,12 +47,15 @@ jobs:
     needs: [install]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: Populate staging database with test data
         run: yarn populate-test-data

--- a/.github/workflows/update-proposal-stages.yml
+++ b/.github/workflows/update-proposal-stages.yml
@@ -12,12 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: yarn-install
         run: |
@@ -34,12 +37,15 @@ jobs:
     needs: [install]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node-24-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: Update proposal stages (production)
         run: npx tsx src/scripts/updateProposalStages.ts

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
-    "@types/node": "^20.19.25",
+    "@types/node": "^24.10.9",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/uuid": "^11.0.0",
@@ -127,6 +127,6 @@
   },
   "packageManager": "yarn@4.7.0",
   "engines": {
-    "node": "20"
+    "node": "24"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,7 +301,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.0"
-    "@types/node": "npm:^20.19.25"
+    "@types/node": "npm:^24.10.9"
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
     "@types/uuid": "npm:^11.0.0"
@@ -4379,12 +4379,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.19.25":
-  version: 20.19.25
-  resolution: "@types/node@npm:20.19.25"
+"@types/node@npm:^24.10.9":
+  version: 24.13.3
+  resolution: "@types/node@npm:24.13.3"
   dependencies:
-    undici-types: "npm:~6.21.0"
-  checksum: 10/f0ed863599da289df5838380e211f9e010414dc7df8127b79f6a7eeca80a8d6e3daf3e58ddad1884f8dfafd17c16b02f56cee1689b7ebdf5df6d0e5770165ac1
+    undici-types: "npm:~7.18.0"
+  checksum: 10/cfa6ed1e16c4624d1e83b09aeb72a2f50a7e17d837bf5a1259a52e346f33a693afd289402d3b6118ce3abea7aff35f2a4f13a0284b96bc5807a50f0e22e1ec77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bump `engines.node` from `20` to `24` in `package.json`
- Update `@types/node` from `^20.19.25` to `^24.10.9`
- Bump `node-version` from `'20'` to `'24'` in the CI `test` and `e2e` jobs

Vercel reads the Node runtime from the `engines` field, so deployments will build with Node 24 automatically. The cron workflows don't pin a Node version and are unaffected.

## Test plan

- [x] `yarn typecheck` passes locally on Node v24.14.0
- [x] Full vitest suite passes (342/342 tests, 40 files)
- [x] `yarn build` (proposals + delegatees + `next build`) succeeds
- [ ] CI green on this PR