### PR TITLE
fix: include logIndex in events primary key

### DIFF
--- a/drizzle/0008_events_log_index_pk.sql
+++ b/drizzle/0008_events_log_index_pk.sql
@@ -1,0 +1,8 @@
+-- Add logIndex to the events PK so multiple same-name events emitted by one
+-- transaction (e.g. ProposalVoteRevokedV2 for two proposals in a single tx)
+-- can coexist. Pre-existing rows are backfilled with 0; the DEFAULT is dropped
+-- immediately so new inserts must always provide the real log index.
+ALTER TABLE "events" ADD COLUMN "logIndex" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "events" ALTER COLUMN "logIndex" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "events" DROP CONSTRAINT "events_eventName_transactionHash_chainId_pk";--> statement-breakpoint
+ALTER TABLE "events" ADD CONSTRAINT "events_eventName_transactionHash_logIndex_chainId_pk" PRIMARY KEY("eventName","transactionHash","logIndex","chainId");

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,709 @@
+{
+  "id": "2050950c-090b-4846-9d9c-08160490c0a7",
+  "prevId": "62e0d64b-9476-4a27-a195-c2d388acdb15",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analyticsEvents": {
+      "name": "analyticsEvents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "eventName": {
+          "name": "eventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_analytics_events_name_properties": {
+          "name": "idx_analytics_events_name_properties",
+          "columns": [
+            {
+              "expression": "properties",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_analytics_events_name": {
+          "name": "idx_analytics_events_name",
+          "columns": [
+            {
+              "expression": "eventName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_analytics_events_created_at": {
+          "name": "idx_analytics_events_created_at",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approvals": {
+      "name": "approvals",
+      "schema": "",
+      "columns": {
+        "chainId": {
+          "name": "chainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposalId": {
+          "name": "proposalId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multisigTxId": {
+          "name": "multisigTxId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approver": {
+          "name": "approver",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmedAt": {
+          "name": "confirmedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockNumber": {
+          "name": "blockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transactionHash": {
+          "name": "transactionHash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "approvals_proposalId_index": {
+          "name": "approvals_proposalId_index",
+          "columns": [
+            {
+              "expression": "proposalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approvals_multisigTxId_index": {
+          "name": "approvals_multisigTxId_index",
+          "columns": [
+            {
+              "expression": "multisigTxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approvals_chainId_index": {
+          "name": "approvals_chainId_index",
+          "columns": [
+            {
+              "expression": "chainId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approvals_chainId_chains_id_fk": {
+          "name": "approvals_chainId_chains_id_fk",
+          "tableFrom": "approvals",
+          "tableTo": "chains",
+          "columnsFrom": ["chainId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "approvals_proposalId_chainId_proposals_id_chainId_fk": {
+          "name": "approvals_proposalId_chainId_proposals_id_chainId_fk",
+          "tableFrom": "approvals",
+          "tableTo": "proposals",
+          "columnsFrom": ["proposalId", "chainId"],
+          "columnsTo": ["id", "chainId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "approvals_chainId_proposalId_approver_pk": {
+          "name": "approvals_chainId_proposalId_approver_pk",
+          "columns": ["chainId", "proposalId", "approver"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocksProcessed": {
+      "name": "blocksProcessed",
+      "schema": "",
+      "columns": {
+        "chainId": {
+          "name": "chainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventName": {
+          "name": "eventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockNumber": {
+          "name": "blockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocksProcessed_chainId_chains_id_fk": {
+          "name": "blocksProcessed_chainId_chains_id_fk",
+          "tableFrom": "blocksProcessed",
+          "tableTo": "chains",
+          "columnsFrom": ["chainId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blocksProcessed_eventName_chainId_pk": {
+          "name": "blocksProcessed_eventName_chainId_pk",
+          "columns": ["eventName", "chainId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chains": {
+      "name": "chains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "chainId": {
+          "name": "chainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventName": {
+          "name": "eventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args": {
+          "name": "args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockNumber": {
+          "name": "blockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transactionHash": {
+          "name": "transactionHash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logIndex": {
+          "name": "logIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingestedAt": {
+          "name": "ingestedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "ingestedVia": {
+          "name": "ingestedVia",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "events_blockNumber_index": {
+          "name": "events_blockNumber_index",
+          "columns": [
+            {
+              "expression": "blockNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_eventName_index": {
+          "name": "events_eventName_index",
+          "columns": [
+            {
+              "expression": "eventName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_chainId_index": {
+          "name": "events_chainId_index",
+          "columns": [
+            {
+              "expression": "chainId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_topics_proposalId_index": {
+          "name": "events_topics_proposalId_index",
+          "columns": [
+            {
+              "expression": "\"topics\"[2]",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_chainId_chains_id_fk": {
+          "name": "events_chainId_chains_id_fk",
+          "tableFrom": "events",
+          "tableTo": "chains",
+          "columnsFrom": ["chainId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "events_eventName_transactionHash_logIndex_chainId_pk": {
+          "name": "events_eventName_transactionHash_logIndex_chainId_pk",
+          "columns": ["eventName", "transactionHash", "logIndex", "chainId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "chainId": {
+          "name": "chainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pastId": {
+          "name": "pastId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cgp": {
+          "name": "cgp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cgpUrl": {
+          "name": "cgpUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cgpUrlRaw": {
+          "name": "cgpUrlRaw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposer": {
+          "name": "proposer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deposit": {
+          "name": "deposit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkWeight": {
+          "name": "networkWeight",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transactionCount": {
+          "name": "transactionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queuedAt": {
+          "name": "queuedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queuedAtBlockNumber": {
+          "name": "queuedAtBlockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dequeuedAt": {
+          "name": "dequeuedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dequeuedAtBlockNumber": {
+          "name": "dequeuedAtBlockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approvedAt": {
+          "name": "approvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approvedAtBlockNumber": {
+          "name": "approvedAtBlockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executedAt": {
+          "name": "executedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executedAtBlockNumber": {
+          "name": "executedAtBlockNumber",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorumVotesRequired": {
+          "name": "quorumVotesRequired",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "constitutionThreshold": {
+          "name": "constitutionThreshold",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposals_chainId_chains_id_fk": {
+          "name": "proposals_chainId_chains_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "chains",
+          "columnsFrom": ["chainId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "proposals_pastId_chainId_proposals_id_chainId_fk": {
+          "name": "proposals_pastId_chainId_proposals_id_chainId_fk",
+          "tableFrom": "proposals",
+          "tableTo": "proposals",
+          "columnsFrom": ["pastId", "chainId"],
+          "columnsTo": ["id", "chainId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposals_id_chainId_pk": {
+          "name": "proposals_id_chainId_pk",
+          "columns": ["id", "chainId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "chainId": {
+          "name": "chainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "voteType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposalId": {
+          "name": "proposalId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_proposalId_chainId_proposals_id_chainId_fk": {
+          "name": "votes_proposalId_chainId_proposals_id_chainId_fk",
+          "tableFrom": "votes",
+          "tableTo": "proposals",
+          "columnsFrom": ["proposalId", "chainId"],
+          "columnsTo": ["id", "chainId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "votes_chainId_type_proposalId_pk": {
+          "name": "votes_chainId_type_proposalId_pk",
+          "columns": ["chainId", "type", "proposalId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.voteType": {
+      "name": "voteType",
+      "schema": "public",
+      "values": ["abstain", "no", "none", "yes"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1781681125157,
       "tag": "0007_event_ingestion_provenance",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1785942610650,
+      "tag": "0008_events_log_index_pk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/webhooks/alchemy/route.test.ts
+++ b/src/app/api/webhooks/alchemy/route.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { createHmac } from 'node:crypto';
+import database from 'src/config/database';
 import { Address } from 'viem';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { POST } from './route';
@@ -89,10 +90,11 @@ function makeAlchemyLog(
     address: string;
     txHash: string;
     txStatus: number;
+    index: number;
   }> = {},
 ) {
   return {
-    index: 0,
+    index: overrides.index ?? 0,
     data: overrides.data ?? '0x',
     topics: overrides.topics ?? [
       '0x1bfe527f3548d9258c2512b6689f0acfccdd0557d80a53845db25fc57e93d8fe', // ProposalQueued
@@ -376,6 +378,19 @@ describe('POST /api/webhooks/alchemy', () => {
       expect(response.status).toBe(200);
       expect(mockFetchHistoricalEventsAndSaveToDBProgressively).not.toHaveBeenCalled();
       expect(mockUpdateProposalsInDB).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('event persistence', () => {
+    it('persists the block-scoped log index of the delivered log', async () => {
+      const log = makeAlchemyLog({ index: 5 });
+      const response = await POST(createSignedRequest(makeAlchemyPayload([log])));
+
+      expect(response.status).toBe(200);
+      const valuesMock = (database as unknown as { values: ReturnType<typeof vi.fn> }).values;
+      const rows = valuesMock.mock.calls.at(-1)?.[0] as { logIndex: number }[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0].logIndex).toBe(5);
     });
   });
 

--- a/src/app/api/webhooks/alchemy/route.ts
+++ b/src/app/api/webhooks/alchemy/route.ts
@@ -107,6 +107,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         data,
         blockNumber: BigInt(block.number),
         transactionHash: log.transaction.hash as `0x${string}`,
+        logIndex: log.index,
         transactionIds,
       });
     }

--- a/src/app/api/webhooks/multibaas/route.test.ts
+++ b/src/app/api/webhooks/multibaas/route.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { createHmac } from 'node:crypto';
+import database from 'src/config/database';
 import { Address } from 'viem';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { POST } from './route';
@@ -84,6 +85,7 @@ function makeMultiBaasEvent(overrides: {
   contractAddress?: string;
   inputs?: { name: string; value: string; hashed: boolean; type: string }[];
   rawFields?: string;
+  indexInLog?: number;
 }) {
   return {
     id: 'test-event-id',
@@ -101,7 +103,7 @@ function makeMultiBaasEvent(overrides: {
           name: 'Governance',
           label: 'Governance',
         },
-        indexInLog: 0,
+        indexInLog: overrides.indexInLog ?? 0,
       },
     },
   };
@@ -344,6 +346,46 @@ describe('POST /api/webhooks/multibaas', () => {
       expect(response.status).toBe(200);
       expect(mockUpdateProposalsInDB).toHaveBeenCalled();
       expect(mockUpdateApprovalsInDB).toHaveBeenCalled();
+    });
+  });
+
+  describe('event persistence', () => {
+    const insertedRows = () => {
+      const valuesMock = (database as unknown as { values: ReturnType<typeof vi.fn> }).values;
+      return valuesMock.mock.calls.at(-1)?.[0] as { logIndex: number }[];
+    };
+
+    it('persists the block-scoped logIndex from rawFields (hex string)', async () => {
+      const event = makeMultiBaasEvent({
+        name: 'ProposalQueued',
+        rawFields: JSON.stringify({
+          topics: ['0x'],
+          data: '0x',
+          blockNumber: '123',
+          transactionHash: '0xaaa',
+          logIndex: '0x1a',
+        }),
+      });
+
+      const response = await POST(createSignedRequest([event]));
+
+      expect(response.status).toBe(200);
+      const rows = insertedRows();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].logIndex).toBe(26);
+    });
+
+    it('falls back to indexInLog when rawFields lacks logIndex', async () => {
+      const event = makeMultiBaasEvent({
+        name: 'ProposalQueued',
+        rawFields: JSON.stringify({ topics: ['0x'], data: '0x' }),
+        indexInLog: 7,
+      });
+
+      const response = await POST(createSignedRequest([event]));
+
+      expect(response.status).toBe(200);
+      expect(insertedRows()[0].logIndex).toBe(7);
     });
   });
 

--- a/src/app/api/webhooks/multibaas/route.ts
+++ b/src/app/api/webhooks/multibaas/route.ts
@@ -57,6 +57,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         args?: Record<string, unknown>;
         blockNumber?: string;
         transactionHash?: string;
+        logIndex?: string | number;
       } = {};
       try {
         parsedFields = JSON.parse(event.rawFields);
@@ -83,6 +84,13 @@ export async function POST(request: NextRequest): Promise<Response> {
         data: (parsedFields.data ?? '0x') as `0x${string}`,
         blockNumber: parsedFields.blockNumber ? BigInt(parsedFields.blockNumber) : 0n,
         transactionHash: (parsedFields.transactionHash ?? '0x') as `0x${string}`,
+        // rawFields is the raw log JSON, whose logIndex (block-scoped, hex
+        // string per JSON-RPC) matches what the cron backfill stores — the PK
+        // then dedupes webhook and cron ingestions of the same event. Fall
+        // back to MultiBaas's indexInLog, then 0.
+        logIndex: Number.isFinite(Number(parsedFields.logIndex))
+          ? Number(parsedFields.logIndex)
+          : (event.indexInLog ?? 0),
         transactionIds,
       });
     }

--- a/src/app/api/webhooks/processWebhookEvents.ts
+++ b/src/app/api/webhooks/processWebhookEvents.ts
@@ -38,6 +38,7 @@ export type ParsedEvent = {
   data: `0x${string}`;
   blockNumber: bigint;
   transactionHash: `0x${string}`;
+  logIndex: number;
   transactionIds: bigint[];
 };
 
@@ -115,8 +116,8 @@ export async function processWebhookEvents(
 /**
  * Stores a single webhook-delivered event into the events table, decoding its
  * args from topics+data so downstream queries (e.g. args->>'proposalId') keep
- * working. Dedupes on the (eventName, transactionHash, chainId) primary key and
- * records ingestion provenance via ingestedVia.
+ * working. Dedupes on the (eventName, transactionHash, logIndex, chainId)
+ * primary key and records ingestion provenance via ingestedVia.
  */
 async function saveWebhookEvent(event: ParsedEvent, isMultiSig: boolean, source: IngestSource) {
   let args: Record<string, unknown> = {};
@@ -140,13 +141,19 @@ async function saveWebhookEvent(event: ParsedEvent, isMultiSig: boolean, source:
     data: event.data,
     blockNumber: event.blockNumber,
     transactionHash: event.transactionHash,
+    logIndex: event.logIndex,
   };
 
   await database
     .insert(eventsTable)
     .values(withIngestionMetadata([row], celoPublicClient.chain.id, source))
     .onConflictDoUpdate({
-      target: [eventsTable.eventName, eventsTable.transactionHash, eventsTable.chainId],
+      target: [
+        eventsTable.eventName,
+        eventsTable.transactionHash,
+        eventsTable.logIndex,
+        eventsTable.chainId,
+      ],
       set: ingestedViaConflictSet,
     });
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -39,6 +39,10 @@ export const eventsTable = pgTable(
     data: text().notNull().$type<`0x${string}`>(),
     blockNumber: numeric({ mode: 'bigint' }).notNull(),
     transactionHash: varchar({ length: 66 }).notNull(),
+    // Position of the log within its block. Distinguishes multiple events of the
+    // same name emitted by a single transaction (e.g. revoking votes on two
+    // proposals at once). Rows ingested before this column existed hold 0.
+    logIndex: integer().notNull(),
     // First time this row was ingested (set on insert, never overwritten on conflict).
     ingestedAt: timestamp({ withTimezone: true }).defaultNow(),
     // Per-provider first-arrival timestamps, e.g.
@@ -48,7 +52,9 @@ export const eventsTable = pgTable(
   },
   (table) => [
     foreignKey({ columns: [table.chainId], foreignColumns: [chainsTable.id] }).onDelete('restrict'),
-    primaryKey({ columns: [table.eventName, table.transactionHash, table.chainId] }),
+    primaryKey({
+      columns: [table.eventName, table.transactionHash, table.logIndex, table.chainId],
+    }),
 
     index().on(table.blockNumber),
     index().on(table.eventName),

--- a/src/features/governance/fetchHistoricalEventsAndSaveToDBProgressively.ts
+++ b/src/features/governance/fetchHistoricalEventsAndSaveToDBProgressively.ts
@@ -101,7 +101,12 @@ export default async function fetchHistoricalEventsAndSaveToDBProgressively(
           .insert(eventsTable)
           .values(withIngestionMetadata(events, client.chain.id, source))
           .onConflictDoUpdate({
-            target: [eventsTable.eventName, eventsTable.transactionHash, eventsTable.chainId],
+            target: [
+              eventsTable.eventName,
+              eventsTable.transactionHash,
+              eventsTable.logIndex,
+              eventsTable.chainId,
+            ],
             set: ingestedViaConflictSet,
           });
         console.log({ inserts: count });

--- a/src/features/governance/fetchHistoricalMultiSigEventsAndSaveToDBProgressively.ts
+++ b/src/features/governance/fetchHistoricalMultiSigEventsAndSaveToDBProgressively.ts
@@ -217,6 +217,7 @@ export default async function fetchHistoricalMultiSigEventsAndSaveToDBProgressiv
                     target: [
                       eventsTable.eventName,
                       eventsTable.transactionHash,
+                      eventsTable.logIndex,
                       eventsTable.chainId,
                     ],
                     set: ingestedViaConflictSet,
@@ -253,7 +254,12 @@ export default async function fetchHistoricalMultiSigEventsAndSaveToDBProgressiv
               .insert(eventsTable)
               .values(withIngestionMetadata(events, client.chain.id, source))
               .onConflictDoUpdate({
-                target: [eventsTable.eventName, eventsTable.transactionHash, eventsTable.chainId],
+                target: [
+                  eventsTable.eventName,
+                  eventsTable.transactionHash,
+                  eventsTable.logIndex,
+                  eventsTable.chainId,
+                ],
                 set: ingestedViaConflictSet,
               });
             console.log({ inserts: count });

--- a/src/features/governance/updateProposalsInDB.test.ts
+++ b/src/features/governance/updateProposalsInDB.test.ts
@@ -53,6 +53,7 @@ describe('updateProposalsInDB', () => {
       data: '0x' as `0x${string}`,
       blockNumber: 59165954n,
       transactionHash: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      logIndex: 0,
     });
 
     const { default: updateProposalsInDB } = await import(

--- a/src/features/governance/utils/events/ingest.test.ts
+++ b/src/features/governance/utils/events/ingest.test.ts
@@ -27,6 +27,7 @@ function baseEvent() {
     ],
     data: '0x' as `0x${string}`,
     blockNumber: 69399792n,
+    logIndex: 0,
   };
 }
 
@@ -35,7 +36,12 @@ async function ingest(source: IngestSource) {
     .insert(eventsTable)
     .values(withIngestionMetadata([baseEvent()], TEST_CHAIN_ID, source))
     .onConflictDoUpdate({
-      target: [eventsTable.eventName, eventsTable.transactionHash, eventsTable.chainId],
+      target: [
+        eventsTable.eventName,
+        eventsTable.transactionHash,
+        eventsTable.logIndex,
+        eventsTable.chainId,
+      ],
       set: ingestedViaConflictSet,
     });
 }
@@ -122,6 +128,33 @@ describe('event ingestion provenance', () => {
     expect(formatIngestedVia(row.ingestedVia)).toMatch(
       /^alchemy \(\d\d:\d\d:\d\d\), multibaas \(\d\d:\d\d:\d\d\)$/,
     );
+  });
+
+  it('stores two same-name events from one transaction as separate rows', async () => {
+    // A single tx can emit the same event twice (e.g. ProposalVoteRevokedV2 for
+    // two proposals when revoking votes on both at once). Before logIndex joined
+    // the PK, batch-inserting these crashed with "ON CONFLICT DO UPDATE command
+    // cannot affect row a second time".
+    const twin = [
+      { ...baseEvent(), args: { proposalId: '301' }, logIndex: 4 },
+      { ...baseEvent(), args: { proposalId: '302' }, logIndex: 5 },
+    ];
+    await database
+      .insert(eventsTable)
+      .values(withIngestionMetadata(twin, TEST_CHAIN_ID, 'cron'))
+      .onConflictDoUpdate({
+        target: [
+          eventsTable.eventName,
+          eventsTable.transactionHash,
+          eventsTable.logIndex,
+          eventsTable.chainId,
+        ],
+        set: ingestedViaConflictSet,
+      });
+
+    const all = await database.select().from(eventsTable);
+    expect(all).toHaveLength(2);
+    expect(all.map((r) => r.logIndex).sort()).toEqual([4, 5]);
   });
 
   it('order of arrival is reflected: MultiBaas first, then Alchemy', async () => {

--- a/src/features/governance/utils/events/proposal.test.ts
+++ b/src/features/governance/utils/events/proposal.test.ts
@@ -13,6 +13,7 @@ describe('decodeAndPrepareProposalEvent', () => {
       eventName: 'ProposalExecuted',
       topics: ['0x'],
       transactionHash: '0x',
+      logIndex: 0,
     };
     const stdoutSpy = vi.spyOn(console, 'info').mockReturnValueOnce();
     await expect(decodeAndPrepareProposalEvent('WrongEvent', mockEvent)).resolves.toEqual(null);
@@ -34,6 +35,7 @@ describe('decodeAndPrepareProposalEvent', () => {
       eventName: 'ProposalExecuted',
       topics: ['0x'],
       transactionHash: '0x',
+      logIndex: 0,
     };
     const errorSpy = vi.spyOn(console, 'error').mockReturnValueOnce();
     await expect(decodeAndPrepareProposalEvent('ProposalExecuted', mockEvent)).resolves.toEqual(
@@ -58,6 +60,7 @@ describe('decodeAndPrepareProposalEvent', () => {
       blockNumber: 23049026n,
       transactionHash: '0x012932ee24ac083380c0950cab182747501dadfa55dba312de66a919260417fd',
       chainId: 42220,
+      logIndex: 0,
     };
 
     await expect(decodeAndPrepareProposalEvent('ProposalExecuted', mockEvent)).resolves.toBe(143n);

--- a/src/features/governance/utils/events/vote.test.ts
+++ b/src/features/governance/utils/events/vote.test.ts
@@ -14,6 +14,7 @@ describe('decodeAndPrepareVoteEvent', () => {
       eventName: 'ProposalVoted',
       topics: ['0x'],
       transactionHash: '0x',
+      logIndex: 0,
     };
     const stdoutSpy = vi.spyOn(console, 'info').mockReturnValueOnce();
     await expect(decodeAndPrepareVoteEvent('WrongEvent', mockEvent, 42220)).resolves.toEqual([]);
@@ -35,6 +36,7 @@ describe('decodeAndPrepareVoteEvent', () => {
       eventName: 'ProposalVoted',
       topics: ['0x'],
       transactionHash: '0x',
+      logIndex: 0,
     };
     const errorSpy = vi.spyOn(console, 'error').mockReturnValueOnce();
     await expect(decodeAndPrepareVoteEvent('ProposalVoted', mockEvent, 42220)).resolves.toEqual([]);
@@ -64,6 +66,7 @@ describe('decodeAndPrepareVoteEvent', () => {
       blockNumber: 21797791n,
       transactionHash: '0x000063192bc74d7b2cb5cbec73572ff9ae649bbac31ae4704f74fda0ab9727c1',
       chainId: 42220,
+      logIndex: 0,
     };
 
     vi.mock('src/features/governance/utils/votes', async (importActual) => {

--- a/src/scripts/populateTestData.ts
+++ b/src/scripts/populateTestData.ts
@@ -81,6 +81,7 @@ function createEvent(
     data: '0x' as `0x${string}`,
     blockNumber: BigInt(blockNumber),
     transactionHash: transactionHash as `0x${string}`,
+    logIndex: 0,
   };
 }
 
@@ -197,6 +198,7 @@ function createConfirmationEvent(
     data: '0x' as `0x${string}`,
     blockNumber: BigInt(blockNumber),
     transactionHash: transactionHash as `0x${string}`,
+    logIndex: 0,
   };
 }
 

--- a/src/scripts/selfHealOrphanedProposals.test.ts
+++ b/src/scripts/selfHealOrphanedProposals.test.ts
@@ -45,6 +45,7 @@ function insertEvent(
     data: '0x' as `0x${string}`,
     blockNumber: 59165954n,
     transactionHash: txHash,
+    logIndex: 0,
   });
 }
 

--- a/src/scripts/updateProposalStages.test.ts
+++ b/src/scripts/updateProposalStages.test.ts
@@ -52,6 +52,7 @@ function insertProposalExecutedEvent(proposalId: number) {
     data: '0x' as `0x${string}`,
     blockNumber: 59165954n,
     transactionHash: txHash,
+    logIndex: 0,
   });
 }
 


### PR DESCRIPTION
## Problem

The hourly `backfill-db` cron has been failing in production and staging since Jul 29 with:

```
PostgresError: ON CONFLICT DO UPDATE command cannot affect row a second time
```

Root cause: tx [`0xf5ec0087...`](https://celoscan.io/tx/0xf5ec0087dc3081e7b6d33a0084f3602b6404b8ad1e9adbaab16d750cbd9fb56d) (block 73422042) emits **two `ProposalVoteRevokedV2` events** — one account revoking votes on proposals 301 and 302 in a single transaction. The `events` PK `(eventName, transactionHash, chainId)` maps both logs to the same row, so:

- the cron's batch `INSERT ... ON CONFLICT` hit the same conflict target twice → crash, retried every hour for ~12 days; `ProposalVoteRevokedV2`, `ProposalUpvoted`, and `ProposalUpvoteRevoked` ingestion was frozen the whole time
- webhook ingestion silently dropped one of the twin events — proposal 301's revocation was never stored

## Fix

Add the block-scoped `logIndex` to the `events` table and its PK → `(eventName, transactionHash, logIndex, chainId)`.

- **Migration 0008** (hand-tuned for a live non-empty table): `ADD COLUMN ... DEFAULT 0 NOT NULL` backfills existing rows, `DROP DEFAULT` forces new inserts to carry the real index, then the PK swap. Runs in one transaction via the existing `yarn migrate` on boot.
- All four `eventsTable` conflict targets updated (governance backfill, multisig backfill ×2, webhook save). Cron paths need no value plumbing — viem logs already carry `logIndex`.
- Webhooks: `ParsedEvent` gains `logIndex`; Alchemy uses `log.index`, MultiBaas reads the raw log's `logIndex` from `rawFields` (hex handled) with `indexInLog` → `0` fallbacks.

## Testing

- [x] New regression test: batch-inserting two same-name events from one tx (the exact crash repro) → both rows stored
- [x] Route-level tests assert the delivered log index reaches the insert for both webhook providers, including the MultiBaas fallback
- [x] Full suite: 342/342; typecheck, lint, prettier clean
- [x] **Verified against a restored production dump** (30,778 events, Docker Postgres 17): migration applied cleanly with zero row loss, all rows backfilled `logIndex=0`, idempotent re-run; then the real `yarn backfill-db` with the prod archive node processed the crashing block (`{ inserts: 2 }`), cleared the 12-day backlog (73421829 → head), and recovered proposal 301's lost revocation; second run idempotent

## Notes

- Legacy rows hold `logIndex = 0`. If an already-stored event is ever re-ingested (e.g. a manual historic re-run of the optimized multisig backfill), it lands as a second row with the true index next to the legacy 0-row. Harmless for vote/approval correctness (verified: all readers scope by proposalId or key by voter); a one-time cleanup query can merge such twins if they appear.
- Stage durations, readers (`JSON_AGG`, `.limit(1)` queries), and provenance accumulation (`ingestedVia` merge) are unaffected — reviewed and covered by existing tests.