### PR TITLE
feat: pin Squid Router to third position on bridge list

### DIFF
--- a/src/app/bridge/page.test.tsx
+++ b/src/app/bridge/page.test.tsx
@@ -11,6 +11,7 @@ const mockUseTrackEvent = vi.mocked(useTrackEventModule.useTrackEvent);
 vi.mock('../actions', () => ({
   getBridgeClickedCounts: vi.fn().mockResolvedValue([]),
 }));
+const mockGetBridgeClickedCounts = vi.mocked((await import('../actions')).getBridgeClickedCounts);
 
 vi.mock('next/image', () => ({
   // eslint-disable-next-line @next/next/no-img-element
@@ -61,5 +62,28 @@ describe('Bridge Page', () => {
     expect(mockTrackEvent).toHaveBeenCalledWith('bridge_clicked', {
       bridgeId: 'portal-bridge',
     });
+  });
+
+  test('should keep Squid Router third even when other bridges have more clicks', async () => {
+    mockGetBridgeClickedCounts.mockResolvedValueOnce([
+      { bridgeId: 'superbridge', count: 100 },
+      { bridgeId: 'usdt0', count: 90 },
+      { bridgeId: 'jumper', count: 50 },
+      { bridgeId: 'relay', count: 40 },
+      { bridgeId: 'portal-bridge', count: 30 },
+    ]);
+
+    render(<Page />);
+    await screen.findByText('Jumper');
+
+    const headings = screen.getAllByRole('heading', { level: 2 });
+    expect(headings.map((heading) => heading.textContent)).toEqual([
+      'Superbridge',
+      'USDT0',
+      'Squid Router',
+      'Jumper',
+      'Relay',
+      'Portal Bridge',
+    ]);
   });
 });

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -8,7 +8,7 @@ import { SolidButton } from 'src/components/buttons/SolidButton';
 import { ChevronIcon } from 'src/components/icons/Chevron';
 import { Section } from 'src/components/layout/Section';
 import { H1 } from 'src/components/text/headers';
-import { BRIDGES } from 'src/config/bridges';
+import { BRIDGES, sortBridgesForDisplay } from 'src/config/bridges';
 import { Bridge } from 'src/types/bridge';
 import { useTrackEvent } from 'src/utils/useTrackEvent';
 import { getBridgeClickedCounts } from '../actions';
@@ -32,17 +32,11 @@ export default function Page() {
           };
         });
 
-        const sorted = bridgesWithCounts.sort((a, b) => {
-          // First sort by click count (descending)
-          if (b.clickCount !== a.clickCount) {
-            return b.clickCount - a.clickCount;
-          }
-          // Then sort by name (ascending)
-          return a.name.localeCompare(b.name);
-        });
-        setSortedBridges(sorted);
+        setSortedBridges(sortBridgesForDisplay(bridgesWithCounts));
       } catch (error) {
-        setSortedBridges(BRIDGES.map((bridge) => ({ ...bridge, clickCount: 0 })));
+        setSortedBridges(
+          sortBridgesForDisplay(BRIDGES.map((bridge) => ({ ...bridge, clickCount: 0 }))),
+        );
       } finally {
         setLoading(false);
       }

--- a/src/config/bridges.test.ts
+++ b/src/config/bridges.test.ts
@@ -1,0 +1,74 @@
+import { BRIDGES, sortBridgesForDisplay } from 'src/config/bridges';
+import { Bridge } from 'src/types/bridge';
+import { describe, expect, test } from 'vitest';
+
+function makeBridge(
+  overrides: Partial<Bridge> & { clickCount: number },
+): Bridge & { clickCount: number } {
+  return {
+    id: 'test-bridge',
+    name: 'Test Bridge',
+    operator: 'Test',
+    href: 'https://example.com',
+    logo: '/logo.png',
+    description: 'Test bridge',
+    ...overrides,
+  };
+}
+
+describe('sortBridgesForDisplay', () => {
+  test('sorts unpinned bridges by click count descending, then name ascending', () => {
+    const bridges = [
+      makeBridge({ id: 'a', name: 'Alpha', clickCount: 5 }),
+      makeBridge({ id: 'b', name: 'Beta', clickCount: 10 }),
+      makeBridge({ id: 'c', name: 'Charlie', clickCount: 5 }),
+    ];
+
+    const sorted = sortBridgesForDisplay(bridges);
+
+    expect(sorted.map((bridge) => bridge.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  test('places pinned bridge at its pinned index regardless of click count', () => {
+    const bridges = [
+      makeBridge({ id: 'a', name: 'Alpha', clickCount: 100 }),
+      makeBridge({ id: 'b', name: 'Beta', clickCount: 90 }),
+      makeBridge({ id: 'pinned', name: 'Pinned', clickCount: 0, pinnedIndex: 1 }),
+      makeBridge({ id: 'c', name: 'Charlie', clickCount: 80 }),
+    ];
+
+    const sorted = sortBridgesForDisplay(bridges);
+
+    expect(sorted.map((bridge) => bridge.id)).toEqual(['a', 'pinned', 'b', 'c']);
+  });
+
+  test('clamps pinned index beyond list length to the end', () => {
+    const bridges = [
+      makeBridge({ id: 'a', name: 'Alpha', clickCount: 10 }),
+      makeBridge({ id: 'pinned', name: 'Pinned', clickCount: 0, pinnedIndex: 99 }),
+    ];
+
+    const sorted = sortBridgesForDisplay(bridges);
+
+    expect(sorted.map((bridge) => bridge.id)).toEqual(['a', 'pinned']);
+  });
+
+  test('does not mutate the input array', () => {
+    const bridges = [
+      makeBridge({ id: 'a', name: 'Alpha', clickCount: 1 }),
+      makeBridge({ id: 'b', name: 'Beta', clickCount: 2 }),
+    ];
+    const originalOrder = bridges.map((bridge) => bridge.id);
+
+    sortBridgesForDisplay(bridges);
+
+    expect(bridges.map((bridge) => bridge.id)).toEqual(originalOrder);
+  });
+});
+
+describe('BRIDGES config', () => {
+  test('pins Squid Router to third position', () => {
+    const squid = BRIDGES.find((bridge) => bridge.id === 'squid-router');
+    expect(squid?.pinnedIndex).toBe(2);
+  });
+});

--- a/src/config/bridges.ts
+++ b/src/config/bridges.ts
@@ -22,6 +22,7 @@ export const BRIDGES: Bridge[] = [
     logo: SquidLogo,
     description:
       'Axelar based cross chain DEX. Good for moving stablecoins between chains, or swapping directly between assets.',
+    pinnedIndex: 2,
   },
   {
     id: 'jumper',
@@ -58,3 +59,28 @@ export const BRIDGES: Bridge[] = [
     description: '1:1 transfers of native USDT powered by the Layer Zero OFT. Best for moving USDT',
   },
 ];
+
+// Orders bridges by click count (descending), then name, and then inserts
+// pinned bridges at their fixed positions so curated placements survive
+// analytics-driven reordering.
+export function sortBridgesForDisplay<T extends Bridge & { clickCount: number }>(
+  bridges: T[],
+): T[] {
+  const pinned = bridges
+    .filter((bridge) => bridge.pinnedIndex !== undefined)
+    .sort((a, b) => (a.pinnedIndex ?? 0) - (b.pinnedIndex ?? 0));
+
+  const sorted = bridges
+    .filter((bridge) => bridge.pinnedIndex === undefined)
+    .sort((a, b) => {
+      if (b.clickCount !== a.clickCount) {
+        return b.clickCount - a.clickCount;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+  for (const bridge of pinned) {
+    sorted.splice(Math.min(bridge.pinnedIndex ?? 0, sorted.length), 0, bridge);
+  }
+  return sorted;
+}

--- a/src/types/bridge.ts
+++ b/src/types/bridge.ts
@@ -7,4 +7,6 @@ export interface Bridge {
   href: string;
   logo: string | StaticImageData;
   description: string;
+  // Zero-based display position that overrides click-count ordering
+  pinnedIndex?: number;
 }


### PR DESCRIPTION
## Summary

The bridge list on `/bridge` is ordered by click-count analytics (PostHog), so there was no way to give a bridge a curated position. This PR adds a pinning mechanism and uses it to place Squid Router third, directly below USDT0.

- Add optional `pinnedIndex` field to the `Bridge` type — a zero-based display position that overrides click-count ordering
- Add `sortBridgesForDisplay()` in `src/config/bridges.ts`: sorts unpinned bridges by click count (desc) then name (asc), then inserts pinned bridges at their fixed positions
- Pin `squid-router` with `pinnedIndex: 2`
- Bridge page uses the helper for both the loaded data path and the error fallback path

## Test plan

- [x] New unit tests for `sortBridgesForDisplay`: pin placement overrides click counts, click/name sort for unpinned bridges, out-of-range index clamps to end, input array not mutated, squid pinned at index 2
- [x] New page test: Squid Router renders third even when every other bridge has more clicks
- [x] Existing bridge page tests pass (8/8 total)
- [x] Lint and prettier clean